### PR TITLE
Speaker, fix visibility during scene init

### DIFF
--- a/Sources/iron/object/SpeakerObject.hx
+++ b/Sources/iron/object/SpeakerObject.hx
@@ -19,8 +19,12 @@ class SpeakerObject extends Object {
 		
 		iron.data.Data.getSound(data.sound, function(sound:kha.Sound) {
 			this.sound = sound;
-			if (visible && data.play_on_start) Scene.active.notifyOnInit(play);
+			Scene.active.notifyOnInit(init);
 		});
+	}
+
+	function init():Void {
+		if (visible && data.play_on_start) play();
 	}
 
 	public function play() {


### PR DESCRIPTION
Visible always returned true, since the visible bool is set in Scene after new() in SpeakerObject has already finished. With this fix init() is run after visible bool has been set in Scene.