### PR TITLE
make write() consistent with fromFloat32Array()

### DIFF
--- a/Sources/iron/math/Mat4.hx
+++ b/Sources/iron/math/Mat4.hx
@@ -521,20 +521,20 @@ class Mat4 {
 
 	public function write(ar:kha.arrays.Float32Array, offset = 0) {
 		ar[offset] = _00;
-		ar[offset + 1] = _01;
-		ar[offset + 2] = _02;
-		ar[offset + 3] = _03;
-		ar[offset + 4] = _10;
+		ar[offset + 1] = _10;
+		ar[offset + 2] = _20;
+		ar[offset + 3] = _30;
+		ar[offset + 4] = _01;
 		ar[offset + 5] = _11;
-		ar[offset + 6] = _12;
-		ar[offset + 7] = _13;
-		ar[offset + 8] = _20;
-		ar[offset + 9] = _21;
+		ar[offset + 6] = _21;
+		ar[offset + 7] = _31;
+		ar[offset + 8] = _02;
+		ar[offset + 9] = _12;
 		ar[offset + 10] = _22;
-		ar[offset + 11] = _23;
-		ar[offset + 12] = _30;
-		ar[offset + 13] = _31;
-		ar[offset + 14] = _32;
+		ar[offset + 11] = _32;
+		ar[offset + 12] = _03;
+		ar[offset + 13] = _13;
+		ar[offset + 14] = _23;
 		ar[offset + 15] = _33;
 	}
 	


### PR DESCRIPTION
`write()` writes in _00, _01, _02, ... order, but everywhere else (fromFloat32Array, constructor, ...) _00, _10, _20, ... is used. This bit me while i was trying to create some objects like this:

```haxe
	var transform = iron.math.Mat4.identity();
	transform.translate(parent._30, parent._31, parent._32);
	transform.write(transformData);
	// trace(transformData);
	var sf: TSceneFormat = ...stuff...;

	var obj: TObj = {
		name: 'obj:${objCounter++}',
		type: 'mesh_object',
		data_ref: 'mesh:${model.modelId}',
		material_refs: ['MyMaterial'],
		transform: { values: transformData },
	}

	sf.objects.push(obj);
```

Does armory use something else than Mat4.write() to write it's files?