### PR TITLE
Update to use lifetime to visually disable/enable particle systems

### DIFF
--- a/Sources/iron/object/ParticleSystem.hx
+++ b/Sources/iron/object/ParticleSystem.hx
@@ -61,6 +61,16 @@ class ParticleSystem {
 		});
 	}
 
+	public function disableLifetime()
+	{
+		lifetime = 0;
+	}
+
+	public function enableLifetime()
+	{
+		lifetime = r.lifetime / frameRate;
+	}
+
 	public function update(object:MeshObject, owner:MeshObject) {
 		if (!ready || object == null || speed == 0.0) return;
 


### PR DESCRIPTION
Update to use lifetime to visually disable/enable particle systems

There is currently two ways in armory for dynamically affect particle systems (sorry if there other ways that I do not realize):
Use speed parameter
This actually "stop" the particle system, however, the particle is still there in air

Limit the lifetime of an article object and re - spawn it
This is doable, but seem to be a very expensive solution (but maybe is wrong) if the particle system is intend to be re - cycle through out the system, for example, car drift smoke,  or weapon firing.

So this patch is try to introduce a third approach, instead of spawning a complete new object, it set the lifetime of each particle to be 0, so all of them will disappear immediately at that exact disable comment.

It may not be the most ideal approach (as the ideal approach will some how let all the current particles finish, and then not spawn new one). But seem to be more easier to manage then spawning a new object with new particle system every time.

Implement result can be found at here (where the brake moment used this mechanism):
https://youtu.be/MNTmtQ_nrE4?t=14

For each tire object, there is an object attachment, during brake at high speed, will produce the particle and disable otherwise
```
       var mo = cast(object, iron.object.MeshObject);
       var psys = mo.particleSystems.length > 0 ? mo.particleSystems[0] : null;
       if (psys == null) mo.particleOwner.particleSystems[0];
...
        // If it it is break, or on dirt, enable it, otherwise disable effect
       if (isBrakeEffect == true)
        {
            psys.enableLifetime();
        }
        else 
        {
            psys.disableLifetime();
        }
```