### PR TITLE
Add docstring to Transform.buildMatrix()

### DIFF
--- a/Sources/iron/object/Transform.hx
+++ b/Sources/iron/object/Transform.hx
@@ -79,6 +79,11 @@ class Transform {
 		local.compose(dloc, drot, dscale);
 	}
 
+	/**
+	 * Update the transform matrix based on `loc`, `rot`, and `scale`. If any
+	 * change is made to `loc`, `rot`, or `scale` `buildMatrix()` must be
+	 * called to update the objects transform.
+	 */
 	public function buildMatrix() {
 		dloc == null ? local.compose(loc, rot, scale) : composeDelta();
 


### PR DESCRIPTION
I know it's small, but I've wondered what this function did before, so I wanted to write the docstring for it.