### PR TITLE
Animation Blend Fix

### DIFF
--- a/Sources/iron/object/Animation.hx
+++ b/Sources/iron/object/Animation.hx
@@ -55,6 +55,8 @@ class Animation {
 			this.blendTime = blendTime;
 			this.blendCurrent = 0.0;
 			this.blendAction = this.action;
+			frameIndex = 0;
+			time = 0.0;			
 		}
 		else frameIndex = -1;
 		this.action = action;


### PR DESCRIPTION
Bug fix when interrupting a loop-able animation and playing a different track, playback started at the frame where last one was interrupted.