### PR TITLE
Fix cache build

### DIFF
--- a/Sources/iron/system/ArmPack.hx
+++ b/Sources/iron/system/ArmPack.hx
@@ -190,7 +190,7 @@ class ArmPack {
 					case "Array", null: { // kha.arrays give null
 						o.writeByte(0xdd);
 						o.writeInt32(d.length);
-						var isInt16 = Std.is(d, #if js js.lib.Int16Array #else Int16ArrayPrivate #end);
+						var isInt16 = Std.is(d, #if js js.html.Int16Array #else Int16ArrayPrivate #end);
 						var isInt = Std.is(d[0], Int);
 						var isFloat = Std.is(d[0], Float);
 


### PR DESCRIPTION
When using Kha extensions in Visual Studio Code, cache building failed and gave the error:

> Failed - try fixing the error(s) and restarting the language server:
> /Users/linghui/ArmorySDK/iron/Sources/iron/system/ArmPack.hx:193: characters 38-40 : Type not found : js.lib.Int16Array

By searching Haxe API I found that Int16Array was in package 'js.html'. Changing js.lib.Int16Array to js.html.Int16Array fixed the issue.