### PR TITLE
Linux VS Code Missing Int16Array and Float32Array

### DIFF
--- a/Sources/iron/system/ArmPack.hx
+++ b/Sources/iron/system/ArmPack.hx
@@ -189,8 +189,8 @@ class ArmPack {
 					case "Array", null: { // kha.arrays give null
 						o.writeByte(0xdd);
 						o.writeInt32(d.length);
-						var isInt16 = Std.is(d, #if js js.lib.Int16Array #else Int16ArrayPrivate #end);
-						var isInt = Std.is(d[0], Int) && !Std.is(d, #if js js.lib.Float32Array #else Float32ArrayPrivate #end);
+						var isInt16 = Std.is(d, #if js js.html.Int16Array #else Int16ArrayPrivate #end);
+						var isInt = Std.is(d[0], Int) && !Std.is(d, #if js js.html.Float32Array #else Float32ArrayPrivate #end);
 						var isFloat = Std.is(d[0], Float);
 
 						if (isInt16) { // Int16Array


### PR DESCRIPTION
I am using Linux(manjaro) and for some reason when i try to launch the project using vs code it say's it cannot find Int16Array inside js.lib. However there is one in js.html. 

I used the package manager to install everything. So it should be up to date. I am guessing this is a linux only issue.