### PR TITLE
Fix null pointer when using object type trait propeties

### DIFF
--- a/Sources/iron/Scene.hx
+++ b/Sources/iron/Scene.hx
@@ -114,6 +114,9 @@ class Scene {
 
 			// Startup scene
 			active.addScene(format.name, null, function(sceneObject: Object) {
+				for (object in sceneObject.getChildren(true)) {
+					createTraits(getRawObjectByName(format, object.name).traits, object);
+				}
 
 				#if arm_terrain
 				if (format.terrain_ref != null)  {
@@ -760,7 +763,6 @@ class Scene {
 				object.properties = new Map();
 				for (p in o.properties) object.properties.set(p.name, p.value);
 			}
-			createTraits(o.traits, object);
 		}
 		done(object);
 	}

--- a/Sources/iron/Scene.hx
+++ b/Sources/iron/Scene.hx
@@ -73,6 +73,8 @@ class Scene {
 	public var traitInits: Array<Void->Void> = [];
 	public var traitRemoves: Array<Void->Void> = [];
 
+	var initializing: Bool; // Is the scene in its initialization phase?
+
 	public function new() {
 		uid = uidCounter++;
 		#if arm_batch
@@ -101,6 +103,7 @@ class Scene {
 		root.name = "Root";
 		traitInits = [];
 		traitRemoves = [];
+		initializing = true;
 		if (global == null) global = new Object();
 	}
 
@@ -135,6 +138,7 @@ class Scene {
 				active.traitInits = [];
 
 				active.sceneParent = sceneObject;
+				active.initializing = false;
 				done(sceneObject);
 			});
 		});
@@ -763,6 +767,10 @@ class Scene {
 				object.properties = new Map();
 				for (p in o.properties) object.properties.set(p.name, p.value);
 			}
+
+			// If the scene is still initializing, traits will be created later
+			// to ensure that object references for trait properties are valid
+			if (!active.initializing) createTraits(o.traits, object);
 		}
 		done(object);
 	}

--- a/Sources/iron/Scene.hx
+++ b/Sources/iron/Scene.hx
@@ -229,6 +229,20 @@ class Scene {
 		return object;
 	}
 
+	/**
+	 * Returns the children of the scene.
+	 *
+	 * If 'recursive' is set to `false`, only direct children will be included
+	 * in the returned array. If `recursive` is `true`, children of children and
+	 * so on will be included too.
+	 *
+	 * @param recursive = false Include children of children
+	 * @return Array<Object>
+	 */
+	public function getChildren(?recursive = false): Array<Object> {
+		return root.getChildren(recursive);
+	}
+
 	public function getChild(name: String): Object {
 		return root.getChild(name);
 	}

--- a/Sources/iron/object/Object.hx
+++ b/Sources/iron/object/Object.hx
@@ -87,6 +87,26 @@ class Object {
 		return null;
 	}
 
+	/**
+	 * Returns the children of the object.
+	 *
+	 * If 'recursive' is set to `false`, only direct children will be included
+	 * in the returned array. If `recursive` is `true`, children of children and
+	 * so on will be included too.
+	 *
+	 * @param recursive = false Include children of children
+	 * @return Array<Object>
+	 */
+	public function getChildren(?recursive = false): Array<Object> {
+		if (!recursive) return children;
+
+		var retChildren = children.copy();
+		for (child in children) {
+			retChildren = retChildren.concat(child.getChildren(recursive));
+		}
+		return retChildren;
+	}
+
 	public function getChildOfType<T: Object>(type: Class<T>): T {
 		if (Std.is(this, type)) return cast this;
 		else {


### PR DESCRIPTION
Previously, using a trait property that referenced an object sometimes led to a null pointer because the corresponding object had not always been created. This PR fixes this by postponing the trait creation to the point where **all** objects are created. Scene traits are not affected by this change.

Additionally, two little helper functions were added in `Objects.hx` and `Scene.hx`.

Related to https://github.com/armory3d/armory/pull/1555