### PR TITLE
Add support for per index array bind constants

### DIFF
--- a/Sources/iron/data/Geometry.hx
+++ b/Sources/iron/data/Geometry.hx
@@ -30,6 +30,7 @@ class Geometry {
 	public var indices: Array<Uint32Array>;
 	public var numTris = 0;
 	public var materialIndices: Array<Int>;
+	public var indexArraysOverrides: Array<Array<TBindConstant>>;
 	public var struct: VertexStructure;
 	public var structLength: Int;
 	public var structStr: String;
@@ -62,11 +63,13 @@ class Geometry {
 	public var actions: Map<String, Array<TObj>> = null;
 	public var mats: Map<String, Array<Mat4>> = null;
 
-	public function new(data: MeshData, indices: Array<Uint32Array>, materialIndices: Array<Int>, usage: Usage = null) {
+	public function new(data: MeshData, indices: Array<Uint32Array>, materialIndices: Array<Int>,
+		indexArraysOverrides: Array<Array<TBindConstant>>, usage: Usage = null) {
 		if (usage == null) usage = Usage.StaticUsage;
 
 		this.indices = indices;
 		this.materialIndices = materialIndices;
+		this.indexArraysOverrides = indexArraysOverrides;
 		this.usage = usage;
 
 		this.vertexArrays = data.raw.vertex_arrays;

--- a/Sources/iron/data/MeshData.hx
+++ b/Sources/iron/data/MeshData.hx
@@ -31,9 +31,13 @@ class MeshData {
 		// Mesh data
 		var indices: Array<Uint32Array> = [];
 		var materialIndices: Array<Int> = [];
-		for (ind in raw.index_arrays) {
-			indices.push(ind.values);
-			materialIndices.push(ind.material);
+		var indexArraysOverrides:Array<Array<TBindConstant>> = [];
+		for (i in 0...raw.index_arrays.length) {
+			indices.push(raw.index_arrays[i].values);
+			materialIndices.push(raw.index_arrays[i].material);
+			if (raw.index_arrays_overrides != null) {
+				indexArraysOverrides.push(raw.index_arrays_overrides[i]);
+			}
 		}
 
 		// Skinning
@@ -84,7 +88,7 @@ class MeshData {
 		}
 
 		// Make vertex buffers
-		geom = new Geometry(this, indices, materialIndices, usage);
+		geom = new Geometry(this, indices, materialIndices, indexArraysOverrides, usage);
 		geom.name = name;
 
 		done(this);

--- a/Sources/iron/data/SceneFormat.hx
+++ b/Sources/iron/data/SceneFormat.hx
@@ -42,6 +42,7 @@ typedef TMeshData = {
 	public var name: String;
 	public var vertex_arrays: Array<TVertexArray>;
 	public var index_arrays: Array<TIndexArray>;
+	@:optional public var index_arrays_overrides: Array<Array<TBindConstant>>;
 	@:optional public var dynamic_usage: Null<Bool>;
 	@:optional public var skin: TSkin;
 	@:optional public var instanced_data: Float32Array;

--- a/Sources/iron/object/MeshObject.hx
+++ b/Sources/iron/object/MeshObject.hx
@@ -286,7 +286,7 @@ class MeshObject extends Object {
 			Uniforms.setContextConstants(g, scontext, bindParams); //
 			Uniforms.setObjectConstants(g, scontext, this);
 			if (materialContexts.length > mi) {
-				Uniforms.setMaterialConstants(g, scontext, materialContexts[mi]);
+				Uniforms.setMaterialConstants(g, scontext, materialContexts[mi], ldata.geom.indexArraysOverrides[i]);
 			}
 
 			// VB / IB

--- a/Sources/iron/object/Uniforms.hx
+++ b/Sources/iron/object/Uniforms.hx
@@ -973,7 +973,8 @@ class Uniforms {
 		}
 	}
 
-	public static function setMaterialConstants(g: Graphics, context: ShaderContext, materialContext: MaterialContext) {
+	public static function setMaterialConstants(g: Graphics, context: ShaderContext, materialContext: MaterialContext,
+												overrideBindConstants:Array<TBindConstant>) {
 		if (materialContext.raw.bind_constants != null) {
 			for (i in 0...materialContext.raw.bind_constants.length) {
 				var matc = materialContext.raw.bind_constants[i];
@@ -986,6 +987,14 @@ class Uniforms {
 				}
 				if (pos == -1) continue;
 				var c = context.raw.constants[pos];
+				if (overrideBindConstants != null) {
+					for (i in 0...overrideBindConstants.length) {
+						if (matc.name == overrideBindConstants[i].name){
+							matc = overrideBindConstants[i];
+							break;
+						}
+					}
+				}
 
 				setMaterialConstant(g, context.constants[pos], c, matc);
 			}


### PR DESCRIPTION
Allow having bind constant per index array instead of just per object.

![image](https://user-images.githubusercontent.com/42382648/77477823-b8086c00-6dfb-11ea-8ab2-32a6bf93bcc4.png)

The monkey's mesh has 500 faces, so currently to do that setup it would be:
* 1 object, 500 materials
* 500 objects, 1 material (1 bind constant per object)
* 500 objects, 500 materials

With this PR you can do 1 object, 1 material, and 500 bind constants and with this save some considerable space by grouping "duplicate" materials that only change some constants.

The setup for testing: 
[build_index_groups_overrides_test.zip](https://github.com/armory3d/iron/files/4377758/build_index_groups_overrides_test.zip)



