### PR TITLE
Align render emitter implementation details to Armory

### DIFF
--- a/Sources/iron/data/SceneFormat.hx
+++ b/Sources/iron/data/SceneFormat.hx
@@ -352,7 +352,6 @@ typedef TParticleData = {
 	public var name: String;
 	public var type: Int; // 0 - Emitter, Hair
 	public var loop: Bool;
-	public var render_emitter: Bool;
 	public var count: Int;
 	public var frame_start: FastFloat;
 	public var frame_end: FastFloat;
@@ -390,6 +389,7 @@ typedef TObj = {
 	public var transform: TTransform;
 	@:optional public var material_refs: Array<String>;
 	@:optional public var particle_refs: Array<TParticleReference>;
+	@:optional public var render_emitter: Bool;
 	@:optional public var is_particle: Null<Bool>; // This object is used as a particle object
 	@:optional public var children: Array<TObj>;
 	@:optional public var group_ref: String; // instance_type

--- a/Sources/iron/object/MeshObject.hx
+++ b/Sources/iron/object/MeshObject.hx
@@ -197,7 +197,6 @@ class MeshObject extends Object {
 	}
 
 	public function render(g: Graphics, context: String, bindParams: Array<String>) {
-
 		if (data == null || !data.geom.ready) return; // Data not yet streamed
 		if (!visible) return; // Skip render if object is hidden
 		if (cullMesh(context, Scene.active.camera, RenderPath.active.light)) return;
@@ -217,12 +216,11 @@ class MeshObject extends Object {
 							c.particleIndex = particleChildren.length - 1;
 						}
 					});
-
 				}
 			}
 			for (i in 0...particleSystems.length) particleSystems[i].update(particleChildren[i], this);
 		}
-		if (particleSystems != null && particleSystems.length > 0 && !particleSystems[0].data.raw.render_emitter) return;
+		if (particleSystems != null && particleSystems.length > 0 && !raw.render_emitter) return;
 		#end
 		if (tilesheet != null) tilesheet.update();
 		if (cullMaterial(context)) return;


### PR DESCRIPTION
Linked to https://github.com/armory3d/armory/pull/1691

`show_instancer_for_render` is an attribute of `bpy.types.Object` so this change is required to support correct emitter rendering in Armory.