### PR TITLE
Allow spawning of objects from added scenes

### DIFF
--- a/Sources/iron/Scene.hx
+++ b/Sources/iron/Scene.hx
@@ -503,7 +503,7 @@ class Scene {
 					var ref = o.material_refs[i];
 					if (o.sceneOfOrigin == null)
 						o.sceneOfOrigin = sceneName;
-					Data.getMaterial(sceneName, ref, function(mat: MaterialData) {
+					Data.getMaterial(o.sceneOfOrigin, ref, function(mat: MaterialData) {
 						materials[i] = mat;
 						materialsLoaded++;
 						if (materialsLoaded == o.material_refs.length) {

--- a/Sources/iron/Scene.hx
+++ b/Sources/iron/Scene.hx
@@ -466,6 +466,10 @@ class Scene {
 
 	public function createObject(o: TObj, format: TSceneFormat, parent: Object, parentObject: TObj, done: Object->Void) {
 		var sceneName = format.name;
+		
+		if (active.raw.objects.indexOf(o) == -1) {
+			active.raw.objects.push(o);
+		}
 
 		if (o.type == "camera_object") {
 			Data.getCamera(sceneName, o.data_ref, function(b: CameraData) {
@@ -497,6 +501,8 @@ class Scene {
 				var materialsLoaded = 0;
 				for (i in 0...o.material_refs.length) {
 					var ref = o.material_refs[i];
+					if (o.sceneOfOrigin == null)
+						o.sceneOfOrigin = sceneName;
 					Data.getMaterial(sceneName, ref, function(mat: MaterialData) {
 						materials[i] = mat;
 						materialsLoaded++;

--- a/Sources/iron/data/SceneFormat.hx
+++ b/Sources/iron/data/SceneFormat.hx
@@ -386,6 +386,7 @@ typedef TObj = {
 #end
 	public var type: String; // object, mesh_object, light_object, camera_object, speaker_object, decal_object
 	public var name: String;
+	public var sceneOfOrigin: String;
 	public var data_ref: String;
 	public var transform: TTransform;
 	@:optional public var material_refs: Array<String>;


### PR DESCRIPTION
These changes/additions make it possible to spawn objects from a scene that is not active but loaded, for example when it has been replaced with `Scene.setActive()` and then re-added with `Scene.addScene()`. This also makes this node setup possible: 
![Unbenannt](https://user-images.githubusercontent.com/30187223/85382083-e3a40b00-b53e-11ea-9e57-1dfbdaddd0a4.PNG)

Before the game couldn't have found the raw data of the objects since the active Scene didn't store them. I think it would be more elegant to extract the raw object data of from the original scene as well when needed, instead of copying them to the active scene, but I don't know how one would do that. 