### PR TITLE
Add support for multiple worlds

### DIFF
--- a/Sources/iron/RenderPath.hx
+++ b/Sources/iron/RenderPath.hx
@@ -495,6 +495,15 @@ class RenderPath {
 		});
 	}
 
+	public function unloadShader(handle: String) {
+		cachedShaderContexts.remove(handle);
+
+		// file/data_name/context
+		var shaderPath = handle.split("/");
+		// Todo: Handle context overrides (see Data.getShader())
+		Data.cachedShaders.remove(shaderPath[1]);
+	}
+
 	public function unload() { for (rt in renderTargets) rt.unload(); }
 
 	public function resize() {

--- a/Sources/iron/Scene.hx
+++ b/Sources/iron/Scene.hx
@@ -190,7 +190,9 @@ class Scene {
 		framePassed = false;
 
 		if (Scene.active != null) {
+			#if (rp_background == "World")
 			RenderPath.active.unloadShader("shader_datas/World_" + Scene.active.raw.world_ref + "/World_" + Scene.active.raw.world_ref);
+			#end
 			Scene.active.remove();
 		}
 

--- a/Sources/iron/Scene.hx
+++ b/Sources/iron/Scene.hx
@@ -188,12 +188,23 @@ class Scene {
 	public static function setActive(sceneName: String, done: Object->Void = null) {
 		if (!framePassed) return;
 		framePassed = false;
-		if (Scene.active != null) Scene.active.remove();
+
+		if (Scene.active != null) {
+			RenderPath.active.unloadShader("shader_datas/World_" + Scene.active.raw.world_ref + "/World_" + Scene.active.raw.world_ref);
+			Scene.active.remove();
+		}
+
 		Data.getSceneRaw(sceneName, function(format: TSceneFormat) {
 			Scene.create(format, function(o: Object) {
 				if (done != null) done(o);
 				#if rp_voxelao // Revoxelize
 				RenderPath.active.voxelized = 0;
+				#end
+
+				#if (rp_background == "World")
+				if (format.world_datas != null) {
+					RenderPath.active.loadShader("shader_datas/World_" + format.world_ref + "/World_" + format.world_ref);
+				}
 				#end
 			});
 		});

--- a/Sources/iron/Scene.hx
+++ b/Sources/iron/Scene.hx
@@ -191,7 +191,9 @@ class Scene {
 
 		if (Scene.active != null) {
 			#if (rp_background == "World")
-			RenderPath.active.unloadShader("shader_datas/World_" + Scene.active.raw.world_ref + "/World_" + Scene.active.raw.world_ref);
+			if (Scene.active.raw.world_ref != null) {
+				RenderPath.active.unloadShader("shader_datas/World_" + Scene.active.raw.world_ref + "/World_" + Scene.active.raw.world_ref);
+			}
 			#end
 			Scene.active.remove();
 		}
@@ -204,7 +206,7 @@ class Scene {
 				#end
 
 				#if (rp_background == "World")
-				if (format.world_datas != null) {
+				if (format.world_ref != null) {
 					RenderPath.active.loadShader("shader_datas/World_" + format.world_ref + "/World_" + format.world_ref);
 				}
 				#end


### PR DESCRIPTION
Required for https://github.com/armory3d/armory/pull/1744

- Added the ability to unload individual shaders (context overrides are not taken into account yet, I don't know exactly how they work)
- World shaders are now loaded/unloaded on scene changes if world background is activated

-----
Ideas for later PR's:
- Add functions for manipulating world attributes
- Allow to change the world for the current scene