### PR TITLE
Fix scene stream for parented mesh objects

### DIFF
--- a/Sources/iron/Scene.hx
+++ b/Sources/iron/Scene.hx
@@ -386,8 +386,6 @@ class Scene {
 						}
 
 						createObject(o, format, parent, parentObject, function(object: Object) {
-							trace('traversing');
-							//if (object != null) 
 							traverseObjects(object, o.children, o, done);
 							if (++objectsTraversed == objectsCount) done();
 						});
@@ -668,11 +666,7 @@ class Scene {
 	}
 
 	function streamMeshObject(object_file: String, data_ref: String, sceneName: String, armature: Armature, materials: Vector<MaterialData>,parent: Object, parentObj: TObj, o: TObj, done: Object->Void) {
-		trace(object_file);
 		sceneStream.add(object_file, data_ref, sceneName, armature, materials, parent, parentObj, o);
-		// TODO: Increase objectsTraversed by full children count
-		//if (o.children != null) objectsTraversed += o.children.length;
-		// Return immediately and stream progressively
 		returnObject(null, null, done);
 	}
 #end
@@ -724,7 +718,6 @@ class Scene {
 			}
 		}
 		else {
-			trace(object_file);
 			#if arm_stream
 			streamMeshObject(
 			#else

--- a/Sources/iron/Scene.hx
+++ b/Sources/iron/Scene.hx
@@ -386,7 +386,9 @@ class Scene {
 						}
 
 						createObject(o, format, parent, parentObject, function(object: Object) {
-							if (object != null) traverseObjects(object, o.children, o, done);
+							trace('traversing');
+							//if (object != null) 
+							traverseObjects(object, o.children, o, done);
 							if (++objectsTraversed == objectsCount) done();
 						});
 					}
@@ -665,10 +667,11 @@ class Scene {
 		return i;
 	}
 
-	function streamMeshObject(object_file: String, data_ref: String, sceneName: String, armature: Armature, materials: Vector<MaterialData>, parent: Object, o: TObj, done: Object->Void) {
-		sceneStream.add(object_file, data_ref, sceneName, armature, materials, parent, o);
+	function streamMeshObject(object_file: String, data_ref: String, sceneName: String, armature: Armature, materials: Vector<MaterialData>,parent: Object, parentObj: TObj, o: TObj, done: Object->Void) {
+		trace(object_file);
+		sceneStream.add(object_file, data_ref, sceneName, armature, materials, parent, parentObj, o);
 		// TODO: Increase objectsTraversed by full children count
-		if (o.children != null) objectsTraversed += o.children.length;
+		//if (o.children != null) objectsTraversed += o.children.length;
 		// Return immediately and stream progressively
 		returnObject(null, null, done);
 	}
@@ -715,22 +718,23 @@ class Scene {
 						#else
 						returnMeshObject(
 						#end
-							object_file, data_ref, sceneName, armature, materials, parent, o, done);
+							object_file, data_ref, sceneName, armature, materials, parent, parentObject, o, done);
 					}
 				});
 			}
 		}
 		else {
+			trace(object_file);
 			#if arm_stream
 			streamMeshObject(
 			#else
 			returnMeshObject(
 			#end
-				object_file, data_ref, sceneName, null, materials, parent, o, done);
+				object_file, data_ref, sceneName, null, materials, parent, parentObject, o, done);
 		}
 	}
 
-	public function returnMeshObject(object_file: String, data_ref: String, sceneName: String, armature: Armature, materials: Vector<MaterialData>, parent: Object, o: TObj, done: Object->Void) {
+	public function returnMeshObject(object_file: String, data_ref: String, sceneName: String, armature: Armature, materials: Vector<MaterialData>, parent: Object, parentObject: TObj, o: TObj, done: Object->Void) {
 		Data.getMesh(object_file, data_ref, function(mesh: MeshData) {
 			if (mesh.isSkinned) {
 				var g = mesh.geom;


### PR DESCRIPTION
Fix for issue [Armory/#1571](https://github.com/armory3d/armory/issues/1571)

Note (When scene stream enabled):

- Parented meshes with independent traits will work without issues. 
- Traits that depend on other objects must be handled manually. 
- Non-mesh objects must be parented as required during runtime.