### PR TITLE
Add support for shadow map atlas

### DIFF
--- a/Sources/iron/object/LightObject.hx
+++ b/Sources/iron/object/LightObject.hx
@@ -279,7 +279,7 @@ class LightObject extends Object {
 	public function setCubeFace(face: Int, camera: CameraObject) {
 		// Set matrix to match cubemap face
 		eye.set(transform.worldx(), transform.worldy(), transform.worldz());
-		#if (!kha_opengl && !kha_webgl)
+		#if (!kha_opengl && !kha_webgl && !arm_shadowmap_atlas)
 		var flip = (face == 2 || face == 3) ? true : false; // Flip +Y, -Y
 		#else
 		var flip = false;

--- a/Sources/iron/object/LightObject.hx
+++ b/Sources/iron/object/LightObject.hx
@@ -37,6 +37,7 @@ class LightObject extends Object {
 	static inline var maxLightsCluster = 4; // Mirror shader constant
 	static inline var clusterNear = 3.0;
 	public static var lightsArray: Float32Array = null;
+	public static var lWVPSpotMatrixArray: Float32Array = null;
 	#if arm_spot
 	public static var lightsArraySpot: Float32Array = null;
 	#end
@@ -467,6 +468,48 @@ class LightObject extends Object {
 				lightsArraySpot[i * 4 + 3] = b;
 			}
 			#end
+			i++;
+		}
+	}
+
+	static var helpMat = Mat4.identity();
+	public static function updateLWVPMatrixArray(object: Object) {
+		if (lWVPSpotMatrixArray == null) {
+			lWVPSpotMatrixArray = new Float32Array(maxLightsCluster * 16);
+		}
+
+		var lights = Scene.active.lights;
+		var n = lights.length > maxLightsCluster ? maxLightsCluster : lights.length;
+		var i = 0;
+
+		for (l in lights) {
+			if (!l.visible)
+				continue;
+			if (l.data.raw.type != "spot")
+				continue;
+			if (i >= n)
+				break;
+
+			(object == null) ? helpMat.setIdentity() : helpMat.setFrom(object.transform.worldUnpack);
+			helpMat.multmat(l.VP);
+			helpMat.multmat(iron.object.Uniforms.biasMat);
+
+			lWVPSpotMatrixArray[i * 16] = helpMat._00;
+			lWVPSpotMatrixArray[i * 16 + 1] = helpMat._10;
+			lWVPSpotMatrixArray[i * 16 + 2] = helpMat._20;
+			lWVPSpotMatrixArray[i * 16 + 3] = helpMat._30;
+			lWVPSpotMatrixArray[i * 16 + 4] = helpMat._01;
+			lWVPSpotMatrixArray[i * 16 + 5] = helpMat._11;
+			lWVPSpotMatrixArray[i * 16 + 6] = helpMat._21;
+			lWVPSpotMatrixArray[i * 16 + 7] = helpMat._31;
+			lWVPSpotMatrixArray[i * 16 + 8] = helpMat._02;
+			lWVPSpotMatrixArray[i * 16 + 9] = helpMat._12;
+			lWVPSpotMatrixArray[i * 16 + 10] = helpMat._22;
+			lWVPSpotMatrixArray[i * 16 + 11] = helpMat._32;
+			lWVPSpotMatrixArray[i * 16 + 12] = helpMat._03;
+			lWVPSpotMatrixArray[i * 16 + 13] = helpMat._13;
+			lWVPSpotMatrixArray[i * 16 + 14] = helpMat._23;
+			lWVPSpotMatrixArray[i * 16 + 15] = helpMat._33;
 			i++;
 		}
 	}

--- a/Sources/iron/object/Uniforms.hx
+++ b/Sources/iron/object/Uniforms.hx
@@ -667,6 +667,11 @@ class Uniforms {
 					fa = LightObject.lightsArraySpot;
 				}
 				#end
+				#if arm_shadowmap_atlas
+				case "_pointLightsAtlasArray": {
+					fa = LightObject.pointLightsData;
+				}
+				#end
 				#end // arm_clusters
 				#if arm_csm
 				case "_cascadeData": {
@@ -992,11 +997,11 @@ class Uniforms {
 					}
 				}
 				#end
-				case "_biasLightWorldViewProjectionMatrixSpotArray":
-				{
-					LightObject.updateLWVPMatrixArray(object);
-					fa = LightObject.lWVPSpotMatrixArray;
+				#if arm_clusters
+				case "_biasLightWorldViewProjectionMatrixSpotArray": {
+					fa = LightObject.updateLWVPMatrixArray(object, "spot");
 				}
+				#end // arm_clusters
 			}
 
 			if (fa == null && externalFloatsLinks != null) {

--- a/Sources/iron/object/Uniforms.hx
+++ b/Sources/iron/object/Uniforms.hx
@@ -992,6 +992,11 @@ class Uniforms {
 					}
 				}
 				#end
+				case "_biasLightWorldViewProjectionMatrixSpotArray":
+				{
+					LightObject.updateLWVPMatrixArray(object);
+					fa = LightObject.lWVPSpotMatrixArray;
+				}
 			}
 
 			if (fa == null && externalFloatsLinks != null) {


### PR DESCRIPTION
These changes are for this from armory https://github.com/armory3d/armory/pull/2102

- ### setTargetStream(), drawMeshesStream(), endStream()

These functions were created as an alternative to allow rendering continuously to the same render target, hence the "Stream" in the names. They are modified versions of setTarget() and drawMeshes(), with some differences but the most important is that the logic that ended the rendering process was moved to a function, so they require to manually call endStream() to close it properly.

What motivated the creation of these functions is that it was observed that drawMeshes() closed the rendering process for you when you called it, which is ok when rendering to a normal render target, but for a render target that is supposedly being rendered over and over, this posed some overhead that could be solved by manually allowing closing the process.

drawMeshesStream() also removed some of the logic from the original, specifically the logic to detect if a light should be skipped,
since this is already done in Inc so it was wasted computing, and the logic to configure the viewport for cascading,
because it didn't make sense to couple this class with atlasing logic.

- ###  zToShadowMapScale(), shadowMapScale, culledLight

These are some of the few changes introduced to `updateClusters()` in order to support LOD and view culling of lights shadows for atlasing. View culling works by detecting incorrect states of clustering which are deemed to result when lights fall out of view.

LOD supports works by taking advantage of the clustering algorithm, which uses the minZ value when computing clusters in zToShadowMapScale() to determine the size of the shadow map for a light arbitrarily.

zToShadowMapScale() is a custom function that plots from [1, 16] (cluster Z slices) to [1.0, 0.0] (shadow map scale). Good enough and cheaper results were observed than if they were implemented with the solution proposed in the clustering shadows algorithm (determine the angle for each cluster).

- ###  discardLight(), discardLightCulled()

These functions were added to make more obvious the dependency of looping (and discarding) lights under the same exact conditions, otherwise is prone to issues because the uniform data for cluster is different from the lights array data. Probably a better solution would be to maybe centralize looping instead of just the conditions to discard lights, but it would require some thought since there are a few different loops for clustering than for lights array

- ###  pointLightsData

this array is updated by Inc from armory, and it's used to provide data to compute UV for point lights in the atlas. It didn't make sense to couple Uniforms nor LightObject with atlasing logic, so it's just in LightObject to avoid coupling.

- ###  updateLWVPMatrixArray(), LWVPMatrixArray

Allow passing arrays of uniform world view projection matrices. The uv coordinates of the specific tiles in the atlas
is composed directly into the transformation, so it saves gpu cycles.