### PR TITLE
Fix flipped shadow for spot light with shadow map atlas

### DIFF
--- a/Sources/iron/object/Uniforms.hx
+++ b/Sources/iron/object/Uniforms.hx
@@ -22,7 +22,7 @@ using StringTools;
 // Structure for setting shader uniforms
 class Uniforms {
 
-	#if (kha_opengl || kha_webgl)
+	#if (kha_opengl || kha_webgl || arm_shadowmap_atlas)
 	public static var biasMat = new Mat4(
 		0.5, 0.0, 0.0, 0.5,
 		0.0, 0.5, 0.0, 0.5,


### PR DESCRIPTION
Fix the issue pointed out at this comment https://github.com/armory3d/armory/issues/2110#issuecomment-783647457