### PR TITLE
Make uniforms for sun shadowmap calculation no longer rely on manual setup.

### DIFF
--- a/Sources/iron/object/Uniforms.hx
+++ b/Sources/iron/object/Uniforms.hx
@@ -681,7 +681,12 @@ class Uniforms {
 				#end // arm_clusters
 				#if arm_csm
 				case "_cascadeData": {
-					if (light != null) fa = light.getCascadeData();
+					for (l in Scene.active.lights) {
+						if (l.data.raw.type == "sun") {
+							fa = l.getCascadeData();
+							break;
+						}
+					}
 				}
 				#end
 			}

--- a/Sources/iron/object/Uniforms.hx
+++ b/Sources/iron/object/Uniforms.hx
@@ -821,24 +821,36 @@ class Uniforms {
 						object == null ? helpMat.setIdentity() : helpMat.setFrom(object.transform.worldUnpack);
 						helpMat.multmat(light.VP);
 						helpMat.multmat(biasMat);
-						#if arm_shadowmap_atlas
-						// tile matrix
-						helpMat2.setIdentity();
-						// scale [0-1] coords to [0-tilescale]
-						helpMat2._00 = light.tileScale[0];
-						helpMat2._11 = light.tileScale[0];
-						// offset coordinate start from [0, 0] to [tile-start-x, tile-start-y]
-						helpMat2._30 = light.tileOffsetX[0];
-						helpMat2._31 = light.tileOffsetY[0];
-						helpMat.multmat(helpMat2);
-						#if (!kha_opengl)
-						helpMat2.setIdentity();
-						helpMat2._11 = -1.0;
-						helpMat2._31 = 1.0;
-						helpMat.multmat(helpMat2);
-						#end
-						#end
 						m = helpMat;
+					}
+				}
+				case "_biasLightWorldViewProjectionMatrixSun": {
+					for (l in iron.Scene.active.lights) {
+						if (l.data.raw.type == "sun") {
+							// object is null for DrawQuad
+							object == null ? helpMat.setIdentity() : helpMat.setFrom(object.transform.worldUnpack);
+							helpMat.multmat(l.VP);
+							helpMat.multmat(biasMat);
+							#if arm_shadowmap_atlas
+							// tile matrix
+							helpMat2.setIdentity();
+							// scale [0-1] coords to [0-tilescale]
+							helpMat2._00 = l.tileScale[0];
+							helpMat2._11 = l.tileScale[0];
+							// offset coordinate start from [0, 0] to [tile-start-x, tile-start-y]
+							helpMat2._30 = l.tileOffsetX[0];
+							helpMat2._31 = l.tileOffsetY[0];
+							helpMat.multmat(helpMat2);
+							#if (!kha_opengl)
+							helpMat2.setIdentity();
+							helpMat2._11 = -1.0;
+							helpMat2._31 = 1.0;
+							helpMat.multmat(helpMat2);
+							#end
+							#end
+							m = helpMat;
+							break;
+						}
 					}
 				}
 				#if rp_probes


### PR DESCRIPTION
It's explained over here at linked PR: https://github.com/armory3d/armory/pull/2147, but basically did three things: 
* Separate the `biasLightWorldViewProjectionMatrix` uniform into two, one where it keeps the original behavior (requiring you to set up renderpath.light manually) and the other for sun where you are not required to set it up.
* Applied the same for the cascade data uniform, loop over lights and find the sun.
* The `biasLightWorldViewProjectionMatrix` case was reverted to before atlas so users are not required to fiddle with atlas variables in order to use this uniform for their custom shaders. 