### PR TITLE
Fix using incorrect bias matrix on webgl without shadow map atlasing

### DIFF
--- a/Sources/iron/object/Uniforms.hx
+++ b/Sources/iron/object/Uniforms.hx
@@ -22,7 +22,7 @@ using StringTools;
 // Structure for setting shader uniforms
 class Uniforms {
 
-	#if (kha_opengl || (arm_shadowmap_atlas && !kha_webgl))
+	#if (kha_opengl || (kha_webgl && !arm_shadowmap_atlas) || (!kha_webgl && arm_shadowmap_atlas))
 	public static var biasMat = new Mat4(
 		0.5, 0.0, 0.0, 0.5,
 		0.0, 0.5, 0.0, 0.5,


### PR DESCRIPTION
Without this it causes an issue of shadows breaking when the camera is
moved if shadow map atlasing is not enabled on webgl.

https://github.com/armory3d/armory/issues/2110#issuecomment-827187431