### PR TITLE
Fix speaker playback

### DIFF
--- a/Sources/iron/object/SpeakerObject.hx
+++ b/Sources/iron/object/SpeakerObject.hx
@@ -42,8 +42,10 @@ class SpeakerObject extends Object {
 			return;
 		}
 		var channel = Audio.play(sound, data.loop, data.stream);
-		channels.push(channel);
-		if (data.attenuation > 0 && channels.length == 1) App.notifyOnUpdate(update);
+		if (channel != null) {
+			channels.push(channel);
+			if (data.attenuation > 0 && channels.length == 1) App.notifyOnUpdate(update);
+		}
 	}
 
 	public function pause() {

--- a/Sources/iron/system/Audio.hx
+++ b/Sources/iron/system/Audio.hx
@@ -2,13 +2,29 @@ package iron.system;
 
 import kha.audio1.AudioChannel;
 
+/**
+	Audio playback. This class wraps around `kha.audio1.Audio`.
+**/
 class Audio {
 
 #if arm_audio
 
 	public function new() {}
 
-	public static function play(sound: kha.Sound, loop = false, stream = false): AudioChannel {
+	/**
+		Plays the given sound.
+
+		If `stream` is `true` and the sound has compressed data, it is streamed
+		from disk instead of being fully loaded into memory. This is useful for
+		longer sounds such as background music.
+
+		This function returns `null` if:
+
+		- there is no unoccupied audio channel available for playback.
+		- the sound has compressed data only but `stream` is `false`. In this
+		  case, call `kha.Sound.uncompress()` first.
+	**/
+	public static function play(sound: kha.Sound, loop = false, stream = false): Null<AudioChannel> {
 		if (stream && sound.compressedData != null) {
 			return kha.audio1.Audio.stream(sound, loop);
 		}


### PR DESCRIPTION
See https://github.com/armory3d/armory/issues/2234.

If too many sounds were played at the same time, it could happen that no channel was available for playback which later caused errors in the speaker's update function. I also added some documentation to the Audio API.