### PR TITLE
changes made to the html5 target so it can run on iOS

### DIFF
--- a/Sources/iron/RenderPath.hx
+++ b/Sources/iron/RenderPath.hx
@@ -641,7 +641,11 @@ class RenderPath {
 	inline function getTextureFormat(s: String): TextureFormat {
 		switch (s) {
 			case "RGBA32": return TextureFormat.RGBA32;
+			#if (rp_hdr && kha_html5)
+			case "RGBA64": return TextureFormat.RGBA32;
+			#else
 			case "RGBA64": return TextureFormat.RGBA64;
+			#end
 			case "RGBA128": return TextureFormat.RGBA128;
 			case "DEPTH16": return TextureFormat.DEPTH16;
 			case "R32": return TextureFormat.A32;


### PR DESCRIPTION
Currently exporting to html5 will give you a black screen on iOS.
This will fix it and also unable to possibility to use advance effects on iOS like Bloom.