### PR TITLE
Add exp() function to vector classes

### DIFF
--- a/Sources/iron/math/Vec2.hx
+++ b/Sources/iron/math/Vec2.hx
@@ -97,6 +97,12 @@ class Vec2 {
 		return this;
 	}
 
+	public inline function exp(v: Vec2): Vec2 {
+		x = Math.exp(v.x);
+		y = Math.exp(v.y);
+		return this;
+	}
+
 	public static inline function distance(v1: Vec2, v2: Vec2): FastFloat {
 		return distancef(v1.x, v1.y, v2.x, v2.y);
 	}

--- a/Sources/iron/math/Vec3.hx
+++ b/Sources/iron/math/Vec3.hx
@@ -134,6 +134,13 @@ class Vec3 {
 		return this;
 	}
 
+	public inline function exp(v: Vec4): Vec4 {
+		x = Math.exp(v.x);
+		y = Math.exp(v.y);
+		z = Math.exp(v.z);
+		return this;
+	}
+
 	public static inline function distance(v1: Vec3, v2: Vec3): FastFloat {
 		return distancef(v1.x, v1.y, v1.z, v2.x, v2.y, v2.z);
 	}

--- a/Sources/iron/math/Vec4.hx
+++ b/Sources/iron/math/Vec4.hx
@@ -171,6 +171,13 @@ class Vec4 {
 		return this;
 	}
 
+	public inline function exp(v: Vec4): Vec4 {
+		x = Math.exp(v.x);
+		y = Math.exp(v.y);
+		z = Math.exp(v.z);
+		return this;
+	}
+
 	public static inline function distance(v1: Vec4, v2: Vec4): FastFloat {
 		return distancef(v1.x, v1.y, v1.z, v2.x, v2.y, v2.z);
 	}


### PR DESCRIPTION
Required by https://github.com/armory3d/armory/pull/2303 for `Vec3`, but I implemented it for the other vector classes as well for consistency.

I'm not sure whether the w component should be included for `Vec4` (like in glsl), but Iron's vectors seem to not use it that much (which makes sense in many cases) so I left it out for now. Also, should there be log/pow/sqrt functions in a similar manner? Or maybe even a functional-programming-style `map()` for applying arbitrary functions to all components?