### PR TITLE
Armpack macro compatibility

### DIFF
--- a/Sources/iron/data/SceneFormat.hx
+++ b/Sources/iron/data/SceneFormat.hx
@@ -1,9 +1,18 @@
 package iron.data;
 
+#if !macro
 import kha.FastFloat;
 import kha.arrays.Float32Array;
 import kha.arrays.Uint32Array;
 import kha.arrays.Int16Array;
+#end
+
+#if macro
+typedef Float32Array = haxe.io.Float32Array;
+typedef Uint32Array = haxe.io.UInt32Array;
+typedef Int16Array = haxe.io.UInt16Array;
+typedef FastFloat = Float;
+#end
 
 #if js
 typedef TSceneFormat = {

--- a/Sources/iron/system/ArmPack.hx
+++ b/Sources/iron/system/ArmPack.hx
@@ -24,20 +24,22 @@ import haxe.io.Bytes;
 import haxe.io.BytesInput;
 import haxe.io.BytesOutput;
 import haxe.io.Eof;
+import iron.data.SceneFormat;
+#if !macro
 import kha.arrays.Float32Array;
 import kha.arrays.Uint32Array;
 import kha.arrays.Int16Array;
-import iron.data.SceneFormat;
+#end
 
 class ArmPack {
 
-	public static inline function decode(b: Bytes): Dynamic {
+	public static inline function decode<T>(b: Bytes): T {
 		var i = new BytesInput(b);
 		i.bigEndian = false;
 		return read(i);
 	}
 
-	static function read(i: BytesInput, key = "", parentKey = ""): Dynamic {
+	static function read(i: BytesInput, key = "", parentKey = "") : Any {
 		try {
 			var b = i.readByte();
 			switch (b) {
@@ -76,7 +78,7 @@ class ArmPack {
 		return null;
 	}
 
-	static function readArray(i: BytesInput, length: Int, key = "", parentKey = ""): Dynamic {
+	static function readArray(i: BytesInput, length: Int, key = "", parentKey = ""): Any {
 		var b = i.readByte();
 		i.position--;
 
@@ -105,7 +107,7 @@ class ArmPack {
 		}
 	}
 
-	static function readMap(i: BytesInput, length: Int, key = "", parentKey = ""): Dynamic {
+	static function readMap(i: BytesInput, length: Int, key = "", parentKey = ""): Any {
 		#if js
 		var out = {};
 		#else
@@ -161,6 +163,8 @@ class ArmPack {
 		}
 	}
 	#end
+
+	#if !macro
 
 	public static inline function encode(d: Dynamic): Bytes {
 		var o = new BytesOutput();
@@ -227,4 +231,6 @@ class ArmPack {
 			default: {}
 		}
 	}
+
+	#end
 }

--- a/Sources/iron/system/Lz4.hx
+++ b/Sources/iron/system/Lz4.hx
@@ -22,8 +22,13 @@
 package iron.system;
 
 import haxe.io.Bytes;
-import kha.arrays.Uint8Array;
+#if macro
+import haxe.io.Int32Array;
+typedef Uint8Array = haxe.io.UInt8Array;
+#else
 import kha.arrays.Int32Array;
+import kha.arrays.Uint8Array;
+#end
 
 class Lz4 {
 


### PR DESCRIPTION
This change allows to use `iron.system.Armpack.decode` in macro context which can be used for all sorts of build time action, as it gives access to all exported data at compile time.

Example usage: https://github.com/tong/armory_examples/tree/macro_armpack-example/macro_armpack
… This just auto creates MeshObject fields in the Game trait class for all meshes in scene.

It would be nice to also have `Armpack.encode` (for modifying exported data at compile time) but there are some unresolved issues.

