### PR TITLE
Reset collection transform after spawn

### DIFF
--- a/Sources/iron/Scene.hx
+++ b/Sources/iron/Scene.hx
@@ -584,6 +584,7 @@ class Scene {
 					if (!isObjectInGroup(groupRef, spawnedObject.parent)) {
 						for (group in format.groups) {
 							if (group.name == groupRef) {
+								spawnedObject.transform.applyParent();
 								spawnedObject.transform.translate(
 									-group.instance_offset[0],
 									-group.instance_offset[1],
@@ -593,7 +594,10 @@ class Scene {
 							}
 						}
 					}
-					if (++spawned == object_refs.length) done();
+					if (++spawned == object_refs.length) {
+						groupOwner.transform.reset();
+						done();
+					}
 				});
 			}
 		}


### PR DESCRIPTION
If a collection is spawned at run-time and if the collection children have a physics trait, the physics objects behave unpredictably since they cannot have parent objects(in this case the collection root) with arbitrary transforms. 

This PR fixes that by re-setting the collection root object's transform after it is spawned while keeping the children transform un-altered. This ensures proper functionality of physics.