### PR TITLE
Defer unloading the world shader until the new shader is loaded

### DIFF
--- a/Sources/iron/Scene.hx
+++ b/Sources/iron/Scene.hx
@@ -193,10 +193,14 @@ class Scene {
 		if (!framePassed) return;
 		framePassed = false;
 
+		// Defer unloading the world shader until the new world shader is loaded
+		// to prevent errors due to a missing world shader inbetween
+		var removeWorldShader: Null<String> = null;
+
 		if (Scene.active != null) {
 			#if (rp_background == "World")
 			if (Scene.active.raw.world_ref != null) {
-				RenderPath.active.unloadShader("shader_datas/World_" + Scene.active.raw.world_ref + "/World_" + Scene.active.raw.world_ref);
+				removeWorldShader = "shader_datas/World_" + Scene.active.raw.world_ref + "/World_" + Scene.active.raw.world_ref;
 			}
 			#end
 			Scene.active.remove();
@@ -210,6 +214,9 @@ class Scene {
 				#end
 
 				#if (rp_background == "World")
+				if (removeWorldShader != null) {
+					RenderPath.active.unloadShader(removeWorldShader);
+				}
 				if (format.world_ref != null) {
 					RenderPath.active.loadShader("shader_datas/World_" + format.world_ref + "/World_" + format.world_ref);
 				}


### PR DESCRIPTION
Because scenes are loaded asynchronously it could happen that world shaders were unloaded before the next scene is ready, resulting in the following error:

```
Uncaught TypeError: cc is undefined
    drawSkydome RenderPath.hx:395
    commands RenderPathDeferred.hx:668
    commands RenderPathCreator.hx:45
    renderFrame RenderPath.hx:143
    renderFrame CameraObject.hx:80
    renderFrame Scene.hx:248
    render App.hx:138
    render System.hx:214
    animate SystemImpl.hx:530
    ...
```

Now world shaders are not unloaded until the scene is ready and the next world shader can be loaded.