### PR TITLE
Fix undefined markerevents

### DIFF
--- a/Sources/iron/object/Animation.hx
+++ b/Sources/iron/object/Animation.hx
@@ -129,7 +129,7 @@ class Animation {
 			for (i in 0...anim.marker_frames.length) {
 				if (frameIndex == anim.marker_frames[i]) {
 					var ar = markerEvents.get(anim.marker_names[i]);
-					for (f in ar) f();
+					if(ar != null) for (f in ar) f();
 				}
 			}
 			lastFrameIndex = frameIndex;


### PR DESCRIPTION
Fix null error if no marker event listener is registered.

```
Trace: TypeError: Cannot read property 'length' of undefined
    at iron_object_BoneAnimation.updateTrack (<anonymous>:16789:20)
```