### PR TITLE
add support for decal object unifroms

### DIFF
--- a/Sources/iron/object/Uniforms.hx
+++ b/Sources/iron/object/Uniforms.hx
@@ -1142,6 +1142,12 @@ class Uniforms {
 			var mo = cast(object, MeshObject);
 			return mo.materials[mo.materialIndex];
 		}
+		#if rp_decals
+		if (object != null && Std.isOfType(object, iron.object.DecalObject)) {
+			var mo = cast(object, DecalObject);
+			return mo.material;
+		}
+		#end
 		return null;
 	}
 


### PR DESCRIPTION
This PR adds support for decal object uniforms. Required by https://github.com/armory3d/armory/pull/2372