### PR TITLE
Fix vertex buffer locking on html5 for deinterleaved buffers and batched meshes

### DIFF
--- a/Sources/iron/data/Geometry.hx
+++ b/Sources/iron/data/Geometry.hx
@@ -226,11 +226,7 @@ class Geometry {
 			// Multi-mat mesh with different vertex structures
 			var struct = getVertexStructure(nVertexArrays);
 			vb = new VertexBuffer(Std.int(positions.values.length / positions.size), struct, usage);
-			#if kha_html5
-			vertices = vb.lock();
-			#else
-			vertices = vb.lockInt16();
-			#end
+			vertices = lockVB(vb);
 			buildVertices(vertices, nVertexArrays, 0, atex && uvs == null, texOffset);
 			vb.unlock();
 			vertexBufferMap.set(key, vb);
@@ -255,11 +251,7 @@ class Geometry {
 #else
 
 		vertexBuffer = new VertexBuffer(Std.int(positions.values.length / positions.size), struct, usage);
-		#if kha_html5
-		vertices = vertexBuffer.lock();
-		#else
-		vertices = vertexBuffer.lockInt16();
-		#end
+		vertices = lockVB(vertexBuffer);
 		buildVertices(vertices, vertexArrays);
 		vertexBuffer.unlock();
 		vertexBufferMap.set(structStr, vertexBuffer);
@@ -285,16 +277,16 @@ class Geometry {
 	}
 
 #if arm_deinterleaved
-	function makeDeinterleavedVB(data: Int16Array, name: String, structLength: Int) {
+	function makeDeinterleavedVB(data: Int16Array, name: String, structLength: Int): VertexBuffer {
 		var struct = new VertexStructure();
 		struct.add(name, structLength == 2 ? VertexData.Short2Norm : VertexData.Short4Norm);
 
 		var vertexBuffer = new VertexBuffer(Std.int(data.length / structLength), struct, usage);
 
-		var vertices = vertexBuffer.lockInt16();
+		var vertices = lockVB(vertexBuffer);
 		for (i in 0...vertices.length) vertices.set(i, data[i]);
-
 		vertexBuffer.unlock();
+
 		return vertexBuffer;
 	}
 #end
@@ -305,6 +297,14 @@ class Geometry {
 
 	inline static function verticesCount(arr: TVertexArray): Int {
 		return Std.int(arr.values.length / arr.size);
+	}
+
+	public inline static function lockVB(vertexBuffer: VertexBuffer): Int16Array {
+		#if kha_html5
+		return cast vertexBuffer.lock();
+		#else
+		return vertexBuffer.lockInt16();
+		#end
 	}
 
 	// Skinned

--- a/Sources/iron/data/Geometry.hx
+++ b/Sources/iron/data/Geometry.hx
@@ -1,5 +1,6 @@
 package iron.data;
 
+import haxe.ds.Vector;
 import kha.graphics4.VertexBuffer;
 import kha.graphics4.IndexBuffer;
 import kha.graphics4.Usage;
@@ -18,7 +19,7 @@ import iron.data.MeshData;
 
 class Geometry {
 #if arm_deinterleaved
-	public var vertexBuffers: Array<InterleavedVertexBuffer>;
+	public var vertexBuffers: Vector<InterleavedVertexBuffer>;
 #else
 	public var vertexBuffer: VertexBuffer;
 	public var vertexBufferMap: Map<String, VertexBuffer> = new Map();
@@ -242,12 +243,12 @@ class Geometry {
 
 #if arm_deinterleaved
 		var vaLength = vertexArrays.length;
-		vertexBuffers = [];
+		vertexBuffers = new Vector(vaLength);
 		for (i in 0...vaLength)
-			vertexBuffers.push({
+			vertexBuffers[i] = {
 				name: vertexArrays[i].attrib,
 				buffer: makeDeinterleavedVB(vertexArrays[i].values, vertexArrays[i].attrib, vertexArrays[i].size)
-			});
+			};
 #else
 
 		vertexBuffer = new VertexBuffer(Std.int(positions.values.length / positions.size), struct, usage);

--- a/Sources/iron/data/MeshBatch.hx
+++ b/Sources/iron/data/MeshBatch.hx
@@ -10,6 +10,7 @@ import kha.graphics4.VertexStructure;
 import kha.graphics4.Graphics;
 import iron.object.MeshObject;
 import iron.object.Uniforms;
+import iron.data.Geometry;
 import iron.data.MaterialData;
 import iron.data.ShaderData;
 import iron.data.SceneFormat;
@@ -161,8 +162,8 @@ class Bucket {
 		for (e in elems) vs.add(e.name, ShaderContext.parseData(e.data));
 
 		var vb = new VertexBuffer(vertexBuffer.count(), vs, Usage.StaticUsage);
-		var to = vb.lockInt16();
-		var from = vertexBuffer.lockInt16();
+		var to = Geometry.lockVB(vb);
+		var from = Geometry.lockVB(vertexBuffer);
 
 		var toOffset = 0;
 		var toStride = Std.int(vb.stride() / 2);
@@ -242,7 +243,7 @@ class Bucket {
 
 		// Build shared buffers
 		vertexBuffer = new VertexBuffer(vcount, vs, Usage.StaticUsage);
-		var vertices = vertexBuffer.lockInt16();
+		var vertices = Geometry.lockVB(vertexBuffer);
 		var offset = 0;
 		for (md in mdatas) {
 			md.geom.copyVertices(vertices, offset, hasUVs);


### PR DESCRIPTION
There were still some usages of `vb.lockInt16()` that wouldn't compile for html5. Now the material_batch and physics_softbody examples compile again for html5, even though the latter still has runtime errors caused by something ammo.js related.

Unfortunately deinterleaved buffers are still broken on D3D11 for meshes with more than one vertex buffer due to https://github.com/Kode/Kinc/issues/338, the values seem to get placed into only one big buffer that is then interpreted as being interleaved.