### PR TITLE
Refactor object parenting

### DIFF
--- a/Sources/iron/Scene.hx
+++ b/Sources/iron/Scene.hx
@@ -258,7 +258,7 @@ class Scene {
 	// Objects
 	public function addObject(parent: Object = null): Object {
 		var object = new Object();
-		parent != null ? parent.addChild(object) : root.addChild(object);
+		parent != null ? object.setParent(parent) : object.setParent(root);
 		return object;
 	}
 
@@ -268,7 +268,7 @@ class Scene {
 	 * If 'recursive' is set to `false`, only direct children will be included
 	 * in the returned array. If `recursive` is `true`, children of children and
 	 * so on will be included too.
-	 * 
+	 *
 	 * @param recursive = `false` Include children of children
 	 * @return `Array<Object>`
 	 */
@@ -329,34 +329,34 @@ class Scene {
 
 	public function addMeshObject(data: MeshData, materials: Vector<MaterialData>, parent: Object = null): MeshObject {
 		var object = new MeshObject(data, materials);
-		parent != null ? parent.addChild(object) : root.addChild(object);
+		parent != null ? object.setParent(parent) : object.setParent(root);
 		return object;
 	}
 
 	public function addLightObject(data: LightData, parent: Object = null): LightObject {
 		var object = new LightObject(data);
-		parent != null ? parent.addChild(object) : root.addChild(object);
+		parent != null ? object.setParent(parent) : object.setParent(root);
 		return object;
 	}
 
 	#if rp_probes
 	public function addProbeObject(data: ProbeData, parent: Object = null): ProbeObject {
 		var object = new ProbeObject(data);
-		parent != null ? parent.addChild(object) : root.addChild(object);
+		parent != null ? object.setParent(parent) : object.setParent(root);
 		return object;
 	}
 	#end
 
 	public function addCameraObject(data: CameraData, parent: Object = null): CameraObject {
 		var object = new CameraObject(data);
-		parent != null ? parent.addChild(object) : root.addChild(object);
+		parent != null ? object.setParent(parent) : object.setParent(root);
 		return object;
 	}
 
 	#if arm_audio
 	public function addSpeakerObject(data: TSpeakerData, parent: Object = null): SpeakerObject {
 		var object = new SpeakerObject(data);
-		parent != null ? parent.addChild(object) : root.addChild(object);
+		parent != null ? object.setParent(parent) : object.setParent(root);
 		return object;
 	}
 	#end
@@ -364,7 +364,7 @@ class Scene {
 	#if rp_decals
 	public function addDecalObject(material: MaterialData, parent: Object = null): DecalObject {
 		var object = new DecalObject(material);
-		parent != null ? parent.addChild(object) : root.addChild(object);
+		parent != null ? object.setParent(parent) : object.setParent(root);
 		return object;
 	}
 	#end

--- a/Sources/iron/object/Object.hx
+++ b/Sources/iron/object/Object.hx
@@ -84,7 +84,7 @@ class Object {
 		@param	keepTransform Optional (defaut false) keep the transform given by the parent or revert to the objects default.
 	**/
 	@:deprecated("removeChild() is deprecated, please use setParent(null) instead")
-	public function removeChild(o: Object, keepTransform = false) {
+	public inline function removeChild(o: Object, keepTransform = false) {
 		o.setParent(null, false, keepTransform);
 	}
 

--- a/Sources/iron/object/Object.hx
+++ b/Sources/iron/object/Object.hx
@@ -37,15 +37,45 @@ class Object {
 	}
 
 	/**
+		Set the given `parentObject` as the parent of this object.
+
+		If `parentObject` is `null`, the object is parented to the scene's
+		`sceneParent`, which is the topmost object of the scene tree.
+		If you want to remove it from the scene, use `Object.remove()` instead.
+
+		If `parentObject` is the object on which this function is called,
+		nothing happens.
+
+		@param parentObject The new parent object.
+		@param parentInverse (Optional) Change the scale of the child object to be relative to the new parents 3D space or use the original scale.
+		@param keepTransform (Optional) When unparenting from the old parent, keep the transform given by the old parent or revert to the object's default.
+	**/
+	public function setParent(parentObject: Object, parentInverse = false, keepTransform = false) {
+		if (parentObject == this || parentObject == parent) return;
+
+		if (parent != null) {
+			parent.children.remove(this);
+			if (keepTransform) this.transform.applyParent();
+			this.parent = null; // rebuild matrix without a parent
+			this.transform.buildMatrix();
+		}
+
+		if (parentObject == null) {
+			parentObject = Scene.active.sceneParent;
+		}
+		parent = parentObject;
+		parent.children.push(this);
+		if (parentInverse) this.transform.applyParentInverse();
+	}
+
+	/**
 		Add a game Object as a child of this game Object.
 		@param	o The game Object instance to be added as a child.
 		@param	parentInverse Optional (default false) change the scale of the child object to be relative to the parents 3D space or use the original scale.
 	**/
-	public function addChild(o: Object, parentInverse = false) {
-		if (o.parent == this) return;
-		children.push(o);
-		o.parent = this;
-		if (parentInverse) o.transform.applyParentInverse();
+	@:deprecated("addChild() is deprecated, please use setParent() instead")
+	public inline function addChild(o: Object, parentInverse = false) {
+		o.setParent(this, parentInverse, false);
 	}
 
 	/**
@@ -53,11 +83,9 @@ class Object {
 		@param	o The game Object instance to be removed.
 		@param	keepTransform Optional (defaut false) keep the transform given by the parent or revert to the objects default.
 	**/
+	@:deprecated("removeChild() is deprecated, please use setParent(null) instead")
 	public function removeChild(o: Object, keepTransform = false) {
-		if (keepTransform) o.transform.applyParent();
-		o.parent = null;
-		o.transform.buildMatrix();
-		children.remove(o);
+		o.setParent(null, false, keepTransform);
 	}
 
 	/**
@@ -92,7 +120,7 @@ class Object {
 
 	/**
 		Returns the children of the object.
-		
+
 		If 'recursive' is set to `false`, only direct children will be included
 		in the returned array. If `recursive` is `true`, children of children and
 		so on will be included too.

--- a/Sources/iron/object/ProbeObject.hx
+++ b/Sources/iron/object/ProbeObject.hx
@@ -76,7 +76,7 @@ class ProbeObject extends Object {
 					DepthStencilFormat.NoDepthAndStencil
 				);
 				camera.name = craw.name;
-				iron.Scene.active.root.addChild(camera);
+				camera.setParent(iron.Scene.active.root);
 				// Make target bindable from render path
 				var rt = new RenderPath.RenderTarget(new RenderPath.RenderTargetRaw());
 				rt.raw.name = raw.name;
@@ -106,7 +106,7 @@ class ProbeObject extends Object {
 					DepthStencilFormat.NoDepthAndStencil
 				);
 				camera.name = craw.name;
-				iron.Scene.active.root.addChild(camera);
+				camera.setParent(iron.Scene.active.root);
 				// Make target bindable from render path
 				var rt = new RenderPath.RenderTarget(new RenderPath.RenderTargetRaw());
 				rt.raw.name = raw.name;


### PR DESCRIPTION
With `Object.addChild()` and `Object.removeChild()` it could happen easily to create invalid scene configurations where one object is the child of multiple other objects but still has only one parent. This invalid configuration could cause endless loops in other parts of Iron, for example when changing scenes.

To prevent this, there is a new function called `setParent()` that unifies and replaces `addChild()` and `removeChild()`. The old functions are now deprecated and show a warning upon compilation, but they are kept for compatibility. `setParent(null)` will parent the object to the scene's `sceneParent` object, which in my view is the most intuitive behaviour in this case.

What confused me a bit is that Iron seems to have two different kinds of scene root objects: first the actual `root` to which the scene is parented, and another object called `sceneParent` which is a child of root which is the parent of the scene's objects, but only if the objects are spawned when the game starts. If objects are spawned during the game or if their parent is cleared by the `Remove Object Parent` node in Armory for example, they are parented to the root object which is one level outside of the scene tree. This can lead to pretty unintuitive behaviour and can cause hard to find errors.

My question now is whether it would make sense to refactor that? Ideally there would be only one root object per scene to which all top-level scene objects are parented to. If another scene is spawned inside the current scene, its root object should be parented to the current's scene root. @luboslenco what do you think about that? Do you remember what problem [this commit](https://github.com/armory3d/iron/commit/3ebb06967d8650c7926fe9e872bf2e7159ef84b5#diff-080869176b69f72d5fcb733c37ec1d8e3758fa93eb6edff20f1225db132d1491L245-R246) fixed?

Thanks to the Discord user Repe for reporting this issue and to @QuantumCoderQC for help with understanding Iron's two root objects :)