### PR TITLE
Fix MeshBatch.remove()

### DIFF
--- a/Sources/iron/data/MeshBatch.hx
+++ b/Sources/iron/data/MeshBatch.hx
@@ -24,7 +24,7 @@ class MeshBatch {
 	public function new() {}
 
 	public function remove() {
-		for (b in buckets) remove();
+		for (b in buckets) b.remove();
 	}
 
 	public static function isBatchable(m: MeshObject): Bool {
@@ -135,8 +135,9 @@ class Bucket {
 	}
 
 	public function remove() {
-		vertexBuffer.delete();
 		indexBuffer.delete();
+		// this.vertexBuffer is in the map, so it's also deleted here
+		for (buf in vertexBufferMap) buf.delete();
 		meshes = [];
 	}
 


### PR DESCRIPTION
Fixes an endless loop reported here https://github.com/armory3d/armory/issues/2404, I also added a fix for a different error described in the issue. The latter is kind of a blind fix because I wasn't able to reproduce it, but some vertex buffers weren't properly deleted and it works for me on both Krom and HL, so that should be fine. Also the fix is very similar to the current code in `Geometry.delete()`.