### PR TITLE
Set sceneParent object before calling trait inits

### DIFF
--- a/Sources/iron/Scene.hx
+++ b/Sources/iron/Scene.hx
@@ -126,7 +126,7 @@ class Scene {
 				}
 
 				#if arm_terrain
-				if (format.terrain_ref != null)  {
+				if (format.terrain_ref != null) {
 					active.terrainStream = new TerrainStream(format.terrain_datas[0]);
 				}
 				#end

--- a/Sources/iron/Scene.hx
+++ b/Sources/iron/Scene.hx
@@ -136,12 +136,13 @@ class Scene {
 				}
 
 				active.camera = active.getCamera(format.camera_ref);
+				active.sceneParent = sceneObject;
+
 				active.ready = true;
 
 				for (f in active.traitInits) f();
 				active.traitInits = [];
 
-				active.sceneParent = sceneObject;
 				active.initializing = false;
 				done(sceneObject);
 			});


### PR DESCRIPTION
`object.setParent(null)` failed inside of trait inits, and I don't see a reason why the sceneParent shouldn't be set earlier.