### PR TITLE
Fix LZ4 encoding/decoding for new Kha array types

### DIFF
--- a/Sources/iron/system/Lz4.hx
+++ b/Sources/iron/system/Lz4.hx
@@ -39,13 +39,8 @@ class Lz4 {
 	}
 
 	public static function encode(b: Bytes): Bytes {
-		#if js
-		var iBuf = new Uint8Array(cast b.getData());
-
-		#else
 		var iBuf: Uint8Array = new Uint8Array(b.length);
 		for (i in 0...b.length) iBuf[i] = b.get(i);
-		#end
 
 		var iLen = iBuf.length;
 		if (iLen >= 0x7e000000) {
@@ -180,13 +175,8 @@ class Lz4 {
 	}
 
 	public static function decode(b: Bytes, oLen: Int): Bytes {
-		#if js
-		var iBuf: Uint8Array = new Uint8Array(cast b.getData());
-
-		#else
 		var iBuf: Uint8Array = new Uint8Array(b.length);
 		for (i in 0...b.length) iBuf[i] = b.get(i);
-		#end
 
 		var iLen = iBuf.length;
 		var oBuf = new Uint8Array(oLen);


### PR DESCRIPTION
Kha arrays on js can no longer be directly constructed from existing data. Thanks to RPaladin for the report!