### PR TITLE
Add support for particle emission from faces and fix scaled volume particles

### DIFF
--- a/Sources/iron/data/SceneFormat.hx
+++ b/Sources/iron/data/SceneFormat.hx
@@ -396,7 +396,7 @@ typedef TParticleData = {
 	public var frame_end: FastFloat;
 	public var lifetime: FastFloat;
 	public var lifetime_random: FastFloat;
-	public var emit_from: Int; // 0 - Vert, 1 - Volume, 2 - Face
+	public var emit_from: Int; // 0 - Vert, 1 - Face, 2 - Volume
 	public var object_align_factor: Float32Array;
 	public var factor_random: FastFloat;
 	public var physics_type: Int; // 0 - No, 1 - Newton

--- a/Sources/iron/data/SceneFormat.hx
+++ b/Sources/iron/data/SceneFormat.hx
@@ -396,7 +396,7 @@ typedef TParticleData = {
 	public var frame_end: FastFloat;
 	public var lifetime: FastFloat;
 	public var lifetime_random: FastFloat;
-	public var emit_from: Int; // 0 - Vert, Face, 1 - Volume
+	public var emit_from: Int; // 0 - Vert, 1 - Volume, 2 - Face
 	public var object_align_factor: Float32Array;
 	public var factor_random: FastFloat;
 	public var physics_type: Int; // 0 - No, 1 - Newton

--- a/Sources/iron/object/ParticleSystem.hx
+++ b/Sources/iron/object/ParticleSystem.hx
@@ -145,46 +145,48 @@ class ParticleSystem {
 	function setupGeomGpu(object: MeshObject, owner: MeshObject) {
 		var instancedData = new Float32Array(particles.length * 3);
 		var i = 0;
-		if (r.emit_from == 0) { // Vert
-			var pa = owner.data.geom.positions;
-			var sc = owner.data.scalePos;
-			for (p in particles) {
-				var j = Std.int(fhash(i) * (pa.values.length / pa.size));
-				instancedData.set(i, pa.values[j * pa.size    ] / 32767 * sc / r.particle_size); i++;
-				instancedData.set(i, pa.values[j * pa.size + 1] / 32767 * sc / r.particle_size); i++;
-				instancedData.set(i, pa.values[j * pa.size + 2] / 32767 * sc / r.particle_size); i++;
-			}
-		}
-		else if (r.emit_from == 1) { // Volume
-			for (p in particles) {
-				instancedData.set(i, (Math.random() * 2.0 - 1.0) * (object.transform.dim.x / 2.0)); i++;
-				instancedData.set(i, (Math.random() * 2.0 - 1.0) * (object.transform.dim.y / 2.0)); i++;
-				instancedData.set(i, (Math.random() * 2.0 - 1.0) * (object.transform.dim.z / 2.0)); i++;
-			}
-		}
-		else if (r.emit_from == 2) { // Face
-			var sc = owner.data.scalePos;
 
-			for (p in particles) {
-				// Choose random index array (there is one per mat) and random face
-				var ia = owner.data.geom.indices[Std.random(owner.data.geom.indices.length)];
-				var faceIndex = Std.random(Std.int(ia.length / 3));
-				var positions = owner.data.geom.positions.values;
+		switch (r.emit_from) {
+			case 0: // Vert
+				var pa = owner.data.geom.positions;
+				var sc = owner.data.scalePos;
+				for (p in particles) {
+					var j = Std.int(fhash(i) * (pa.values.length / pa.size));
+					instancedData.set(i, pa.values[j * pa.size    ] / 32767 * sc / r.particle_size); i++;
+					instancedData.set(i, pa.values[j * pa.size + 1] / 32767 * sc / r.particle_size); i++;
+					instancedData.set(i, pa.values[j * pa.size + 2] / 32767 * sc / r.particle_size); i++;
+				}
 
-				var i0 = ia[faceIndex * 3 + 0];
-				var i1 = ia[faceIndex * 3 + 1];
-				var i2 = ia[faceIndex * 3 + 2];
+			case 1: // Volume
+				for (p in particles) {
+					instancedData.set(i, (Math.random() * 2.0 - 1.0) * (object.transform.dim.x / 2.0)); i++;
+					instancedData.set(i, (Math.random() * 2.0 - 1.0) * (object.transform.dim.y / 2.0)); i++;
+					instancedData.set(i, (Math.random() * 2.0 - 1.0) * (object.transform.dim.z / 2.0)); i++;
+				}
 
-				var v0 = new Vec3(positions[i0 * 4], positions[i0 * 4 + 1], positions[i0 * 4 + 2]);
-				var v1 = new Vec3(positions[i1 * 4], positions[i1 * 4 + 1], positions[i1 * 4 + 2]);
-				var v2 = new Vec3(positions[i2 * 4], positions[i2 * 4 + 1], positions[i2 * 4 + 2]);
+			case 2: // Face
+				var sc = owner.data.scalePos;
 
-				var pos = randomPointInTriangle(v0, v1, v2);
+				for (p in particles) {
+					// Choose random index array (there is one per mat) and random face
+					var ia = owner.data.geom.indices[Std.random(owner.data.geom.indices.length)];
+					var faceIndex = Std.random(Std.int(ia.length / 3));
+					var positions = owner.data.geom.positions.values;
 
-				instancedData.set(i, pos.x / 32767 * sc / r.particle_size); i++;
-				instancedData.set(i, pos.y / 32767 * sc / r.particle_size); i++;
-				instancedData.set(i, pos.z / 32767 * sc / r.particle_size); i++;
-			}
+					var i0 = ia[faceIndex * 3 + 0];
+					var i1 = ia[faceIndex * 3 + 1];
+					var i2 = ia[faceIndex * 3 + 2];
+
+					var v0 = new Vec3(positions[i0 * 4], positions[i0 * 4 + 1], positions[i0 * 4 + 2]);
+					var v1 = new Vec3(positions[i1 * 4], positions[i1 * 4 + 1], positions[i1 * 4 + 2]);
+					var v2 = new Vec3(positions[i2 * 4], positions[i2 * 4 + 1], positions[i2 * 4 + 2]);
+
+					var pos = randomPointInTriangle(v0, v1, v2);
+
+					instancedData.set(i, pos.x / 32767 * sc / r.particle_size); i++;
+					instancedData.set(i, pos.y / 32767 * sc / r.particle_size); i++;
+					instancedData.set(i, pos.z / 32767 * sc / r.particle_size); i++;
+				}
 		}
 		object.data.geom.setupInstanced(instancedData, 1, Usage.StaticUsage);
 	}

--- a/Sources/iron/object/ParticleSystem.hx
+++ b/Sources/iron/object/ParticleSystem.hx
@@ -146,32 +146,34 @@ class ParticleSystem {
 		var instancedData = new Float32Array(particles.length * 3);
 		var i = 0;
 
+		var scaleFactorVol = owner.data.scalePos / r.particle_size;
+		var scaleFactorVertFace = 1 / 32767 * scaleFactorVol;
+
 		switch (r.emit_from) {
 			case 0: // Vert
 				var pa = owner.data.geom.positions;
-				var sc = owner.data.scalePos;
+
 				for (p in particles) {
 					var j = Std.int(fhash(i) * (pa.values.length / pa.size));
-					instancedData.set(i, pa.values[j * pa.size    ] / 32767 * sc / r.particle_size); i++;
-					instancedData.set(i, pa.values[j * pa.size + 1] / 32767 * sc / r.particle_size); i++;
-					instancedData.set(i, pa.values[j * pa.size + 2] / 32767 * sc / r.particle_size); i++;
+					instancedData.set(i, pa.values[j * pa.size    ] * scaleFactorVertFace); i++;
+					instancedData.set(i, pa.values[j * pa.size + 1] * scaleFactorVertFace); i++;
+					instancedData.set(i, pa.values[j * pa.size + 2] * scaleFactorVertFace); i++;
 				}
 
 			case 1: // Volume
 				for (p in particles) {
-					instancedData.set(i, (Math.random() * 2.0 - 1.0) * (object.transform.dim.x / 2.0)); i++;
-					instancedData.set(i, (Math.random() * 2.0 - 1.0) * (object.transform.dim.y / 2.0)); i++;
-					instancedData.set(i, (Math.random() * 2.0 - 1.0) * (object.transform.dim.z / 2.0)); i++;
+					instancedData.set(i, (Math.random() * 2.0 - 1.0) * (object.transform.dim.x / 2.0) * scaleFactorVol); i++;
+					instancedData.set(i, (Math.random() * 2.0 - 1.0) * (object.transform.dim.y / 2.0) * scaleFactorVol); i++;
+					instancedData.set(i, (Math.random() * 2.0 - 1.0) * (object.transform.dim.z / 2.0) * scaleFactorVol); i++;
 				}
 
 			case 2: // Face
-				var sc = owner.data.scalePos;
+				var positions = owner.data.geom.positions.values;
 
 				for (p in particles) {
 					// Choose random index array (there is one per mat) and random face
 					var ia = owner.data.geom.indices[Std.random(owner.data.geom.indices.length)];
 					var faceIndex = Std.random(Std.int(ia.length / 3));
-					var positions = owner.data.geom.positions.values;
 
 					var i0 = ia[faceIndex * 3 + 0];
 					var i1 = ia[faceIndex * 3 + 1];
@@ -183,9 +185,9 @@ class ParticleSystem {
 
 					var pos = randomPointInTriangle(v0, v1, v2);
 
-					instancedData.set(i, pos.x / 32767 * sc / r.particle_size); i++;
-					instancedData.set(i, pos.y / 32767 * sc / r.particle_size); i++;
-					instancedData.set(i, pos.z / 32767 * sc / r.particle_size); i++;
+					instancedData.set(i, pos.x * scaleFactorVertFace); i++;
+					instancedData.set(i, pos.y * scaleFactorVertFace); i++;
+					instancedData.set(i, pos.z * scaleFactorVertFace); i++;
 				}
 		}
 		object.data.geom.setupInstanced(instancedData, 1, Usage.StaticUsage);

--- a/Sources/iron/object/ParticleSystem.hx
+++ b/Sources/iron/object/ParticleSystem.hx
@@ -160,14 +160,7 @@ class ParticleSystem {
 					instancedData.set(i, pa.values[j * pa.size + 2] * scaleFactorVertFace); i++;
 				}
 
-			case 1: // Volume
-				for (p in particles) {
-					instancedData.set(i, (Math.random() * 2.0 - 1.0) * (object.transform.dim.x / 2.0) * scaleFactorVol); i++;
-					instancedData.set(i, (Math.random() * 2.0 - 1.0) * (object.transform.dim.y / 2.0) * scaleFactorVol); i++;
-					instancedData.set(i, (Math.random() * 2.0 - 1.0) * (object.transform.dim.z / 2.0) * scaleFactorVol); i++;
-				}
-
-			case 2: // Face
+			case 1: // Face
 				var positions = owner.data.geom.positions.values;
 
 				for (p in particles) {
@@ -188,6 +181,13 @@ class ParticleSystem {
 					instancedData.set(i, pos.x * scaleFactorVertFace); i++;
 					instancedData.set(i, pos.y * scaleFactorVertFace); i++;
 					instancedData.set(i, pos.z * scaleFactorVertFace); i++;
+				}
+
+			case 2: // Volume
+				for (p in particles) {
+					instancedData.set(i, (Math.random() * 2.0 - 1.0) * (object.transform.dim.x / 2.0) * scaleFactorVol); i++;
+					instancedData.set(i, (Math.random() * 2.0 - 1.0) * (object.transform.dim.y / 2.0) * scaleFactorVol); i++;
+					instancedData.set(i, (Math.random() * 2.0 - 1.0) * (object.transform.dim.z / 2.0) * scaleFactorVol); i++;
 				}
 		}
 		object.data.geom.setupInstanced(instancedData, 1, Usage.StaticUsage);


### PR DESCRIPTION
This PR adds support for particles that are spawned at random locations on random faces and fixes particle positions in case the particles are scaled and spawned in volumes.

I wasn't sure where the new `randomPointInTriangle()` should go to, feel free to move it somewhere else :)

Unfortunately the `emit_from` ids are now different than the order used in Blender: Blender would be 0: vert, 1: faces, 2: volume. I didn't change it because it might break compatibility with already exported .arm files, but please let me know if I should change it. It's not important though.