### PR TITLE
Add sun world matrix uniform

### DIFF
--- a/Sources/iron/object/Uniforms.hx
+++ b/Sources/iron/object/Uniforms.hx
@@ -799,6 +799,13 @@ class Uniforms {
 					m = cast(object, MeshObject).prevMatrix;
 				}
 				#end
+				case "_sunWorldMatrix": {
+					var sun = RenderPath.active.sun;
+					if (sun != null) {
+						helpMat.setFrom(sun.transform.worldUnpack);
+						m = helpMat;
+					}
+				}
 				case "_lightWorldViewProjectionMatrix": {
 					if (light != null) {
 						// object is null for DrawQuad


### PR DESCRIPTION
Useful when you want to project (uv-) coordinates from the sun's point of view.