### PR TITLE
Make tilesheet frame rate independent of render path + fix race condition

### DIFF
--- a/Sources/iron/Scene.hx
+++ b/Sources/iron/Scene.hx
@@ -13,6 +13,7 @@ import iron.object.LightObject;
 import iron.object.SpeakerObject;
 import iron.object.DecalObject;
 import iron.object.ProbeObject;
+import iron.object.Tilesheet;
 import iron.data.CameraData;
 import iron.data.MeshData;
 import iron.data.LightData;
@@ -63,6 +64,7 @@ class Scene {
 	#end
 	public var empties: Array<Object>;
 	public var animations: Array<Animation>;
+	public var tilesheets: Array<Tilesheet>;
 	#if arm_skin
 	public var armatures: Array<Armature>;
 	#end
@@ -99,6 +101,7 @@ class Scene {
 		#end
 		empties = [];
 		animations = [];
+		tilesheets = [];
 		#if arm_skin
 		armatures = [];
 		#end
@@ -241,6 +244,10 @@ class Scene {
 	public function renderFrame(g: kha.graphics4.Graphics) {
 		if (!ready || RenderPath.active == null) return;
 		framePassed = true;
+
+		for (tilesheet in tilesheets) {
+			tilesheet.update();
+		}
 
 		// Render probes
 		#if rp_probes

--- a/Sources/iron/object/MeshObject.hx
+++ b/Sources/iron/object/MeshObject.hx
@@ -238,7 +238,6 @@ class MeshObject extends Object {
 		if (particleSystems != null && particleSystems.length > 0 && !raw.render_emitter) return;
 		#end
 
-		if (tilesheet != null) tilesheet.update();
 		if (cullMaterial(context)) return;
 
 		// Get lod


### PR DESCRIPTION
Fixes https://github.com/armory3d/armory/issues/1437.

Previously, `Tilesheet.update()` was called from `MeshObject.render()` which could be called multiple times per frame (with different contexts or in case of VR even twice with the same context). Because the tilesheet used the render frame time as a delta time, this could lead to wrong frame rates for example when there was both a "mesh" and a "shadowmap" context rendered in one frame.

Now, all active tilesheets are updated once at the beginning of each frame and if the animation frame rate is higher than the render frame rate, multiple animation frames are now skipped correctly which wasn't the case before. This also fixes a possible race condition that could happen if the tilesheet frame is advanced in between multiple render passes. The centralized update could also improve cache coherency.

I also decided to make `Tilesheet.update()` private because it assumes that it is called only once per render frame.