### PR TITLE
Fix null error if no Pen device exists

### DIFF
--- a/Sources/iron/system/Input.hx
+++ b/Sources/iron/system/Input.hx
@@ -341,7 +341,8 @@ class Pen extends VirtualInput {
 	var lastY = -1.0;
 
 	public function new() {
-		kha.input.Pen.get().notify(downListener, upListener, moveListener);
+	    var pen = kha.input.Pen.get();
+        if(pen != null) pen.notify(downListener, upListener, moveListener);
 	}
 
 	public function endFrame() {


### PR DESCRIPTION
Mouse usage fails if no Pen device exists. `Uncaught TypeError: Cannot read properties of null (reading 'notify')`.
This is critical since html5 doesn't support Pen devices.