### PR TITLE
Reworked tilesheets to implement support for Sparrow atlases.

### DIFF
--- a/Sources/iron/data/SceneFormat.hx
+++ b/Sources/iron/data/SceneFormat.hx
@@ -367,9 +367,11 @@ typedef TTilesheetData = {
 @:structInit class TTilesheetData {
 #end
 	public var name: String;
+	public var format: String; // GRID, SPARROW
 	public var tilesx: Int;
 	public var tilesy: Int;
 	public var framerate: Int;
+	public var atlas_data: String; // XML text data
 	public var actions: Array<TTilesheetAction>;
 }
 
@@ -382,6 +384,7 @@ typedef TTilesheetAction = {
 	public var start: Int;
 	public var end: Int;
 	public var loop: Bool;
+	public var prefix: String;
 }
 
 #if js

--- a/Sources/iron/object/Tilesheet.hx
+++ b/Sources/iron/object/Tilesheet.hx
@@ -3,22 +3,152 @@ package iron.object;
 import iron.Scene;
 import iron.data.Data;
 import iron.data.SceneFormat;
+import iron.object.tilesheet.TilesheetActionData;
+import iron.object.tilesheet.TilesheetActionData.TilesheetAction;
+import iron.object.tilesheet.TilesheetFrameData;
+import iron.object.tilesheet.TilesheetFrameData.TilesheetFrame;
 import iron.system.Time;
 
 @:allow(iron.Scene)
 class Tilesheet {
 
-	public var tileX = 0.0; // Tile offset on tilesheet texture 0-1
-	public var tileY = 0.0;
+	/**
+	 * Raw tilesheet data
+	 */
+	public var raw:TTilesheetData;
 
-	public var raw: TTilesheetData;
-	public var action: TTilesheetAction = null;
-	var ready: Bool;
+	/**
+	 * Parsed frame data for this tilesheet
+	 */
+	public var frameData:TilesheetFrameData;
 
+	/**
+	 * Parsed action data for this tilesheet
+	 */
+	public var actionData:TilesheetActionData;
+
+	/**
+	 * Parsed action data for the current action
+	 */
+	public var currentAction:TilesheetAction;
+
+	/**
+	 * RAW data for the current action.
+	 */
+	public var action(get, null):TTilesheetAction;
+
+	function get_action():TTilesheetAction {
+		return currentAction.raw;
+	}
+
+	public var textureWidth(get, null):Int;
+
+	function get_textureWidth():Int {
+		return frameData.textureWidth;
+	}
+
+	public var textureHeight(get, null):Int;
+
+	function get_textureHeight():Int {
+		return frameData.textureHeight;
+	}
+
+	public var framerate(get, null):Float;
+
+	function get_framerate():Float {
+		return raw.framerate;
+	}
+
+	public var frameTime(get, null):Float;
+
+	function get_frameTime():Float {
+		return 1 / this.framerate;
+	}
+
+	public var tileUVX(get, null):Float;
+
+	function get_tileUVX():Float {
+		if (currentFrame == null) return 0.0;
+		return currentFrame.x / textureWidth;
+	}
+
+	public var tileUVY(get, null):Float;
+
+	function get_tileUVY():Float {
+		if (currentFrame == null) return 0.0;
+		return currentFrame.y / textureHeight;
+	}
+
+	public var tileUVFrameX(get, null):Float;
+
+	function get_tileUVFrameX():Float {
+		if (currentFrame == null) return 0.0;
+		return (currentFrame.x + currentFrame.frameX) / textureWidth;
+	}
+
+	public var tileUVFrameY(get, null):Float;
+
+	function get_tileUVFrameY():Float {
+		if (currentFrame == null) return 0.0;
+		return (currentFrame.y + currentFrame.frameY) / textureHeight;
+	}
+
+	public var tileUVFrameWidth(get, null):Float;
+
+	function get_tileUVFrameWidth():Float {
+		if (currentFrame == null) return 0.0;
+		return (currentFrame.x + currentFrame.frameX + currentFrame.frameWidth) / textureWidth;
+	}
+
+	public var tileUVFrameHeight(get, null):Float;
+
+	function get_tileUVFrameHeight():Float {
+		if (currentFrame == null) return 0.0;
+		return (currentFrame.y + currentFrame.frameY + currentFrame.frameHeight) / textureHeight;
+	}
+
+	public var tileUVWidth(get, null):Float;
+
+	function get_tileUVWidth():Float {
+		if (currentFrame == null) return 0;
+		return (currentFrame.x + currentFrame.frameWidth) / textureWidth;
+	}
+
+	public var tileUVHeight(get, null):Float;
+
+	function get_tileUVHeight():Float {
+		if (currentFrame == null) return 0;
+		return (currentFrame.y + currentFrame.frameHeight) / textureHeight;
+	}
+
+	public var currentFrame(get, null):TilesheetFrame;
+	
+	function get_currentFrame():TilesheetFrame {
+		if (currentAction == null) return null;
+		return currentAction.frames[actionFrameIndex];
+	}
+
+	/**
+	 * Whether tilesheet action playback is paused.
+	 */
 	public var paused = false;
-	public var frame = 0;
-	var time = 0.0;
+
+	/**
+	 * A callback that is called when the current action completes.
+	 */
 	var onActionComplete: Void->Void = null;
+
+	var ready:Bool;
+	
+	/**
+	 * A counter to track real time since the last animation frame.
+	 */
+	var time = 0.0;
+
+	/**
+	 * Current frame index in the current action.
+	 */
+	var actionFrameIndex = 0;
 
 	public function new(sceneName: String, tilesheet_ref: String, tilesheet_action_ref: String) {
 		ready = false;
@@ -26,8 +156,14 @@ class Tilesheet {
 			for (ts in format.tilesheet_datas) {
 				if (ts.name == tilesheet_ref) {
 					raw = ts;
+					frameData = buildFrameData();
+					actionData = buildActionData();
+
 					Scene.active.tilesheets.push(this);
+
+					// Play the starting action.
 					play(tilesheet_action_ref);
+
 					ready = true;
 					break;
 				}
@@ -35,15 +171,35 @@ class Tilesheet {
 		});
 	}
 
+	function buildFrameData():TilesheetFrameData {
+		switch(raw.format) {
+			case "GRID":
+				return TilesheetFrameData.fromGrid(raw.tilesx, raw.tilesy);
+			case "SPARROW":
+				return TilesheetFrameData.fromSparrow(raw.atlas_data);
+			default:
+				return null;
+		}
+	}
+
+	function buildActionData():TilesheetActionData {
+		switch(raw.format) {
+			case "GRID":
+				return TilesheetActionData.fromGrid(frameData, raw.actions);
+			case "SPARROW":
+				return TilesheetActionData.fromSparrow(frameData, raw.actions);
+			default:
+				return null;
+		}
+	}
+
 	public function play(action_ref: String, onActionComplete: Void->Void = null) {
 		this.onActionComplete = onActionComplete;
-		for (a in raw.actions) {
-			if (a.name == action_ref) {
-				action = a;
-				break;
-			}
-		}
-		setFrame(action.start);
+
+		this.currentAction = actionData.getAction(action_ref);
+
+		actionFrameIndex = 0;
+
 		paused = false;
 	}
 
@@ -55,16 +211,27 @@ class Tilesheet {
 		paused = false;
 	}
 
+	public function restart() {
+		actionFrameIndex = 0;
+		paused = false;
+	}
+
+	public function stop() {
+		actionFrameIndex = 0;
+		paused = true;
+	}
+
 	public function remove() {
 		Scene.active.tilesheets.remove(this);
 	}
 
 	function update() {
-		if (!ready || paused || action.start >= action.end) return;
+		if (!ready || paused) return;
+		if (currentAction == null) return;
+		if (currentAction.frames.length == 0) return;
 
 		time += Time.realDelta;
 
-		var frameTime = 1 / raw.framerate;
 		var framesToAdvance = 0;
 
 		// Check how many animation frames passed during the last render frame
@@ -76,22 +243,17 @@ class Tilesheet {
 		}
 
 		if (framesToAdvance != 0) {
-			setFrame(frame + framesToAdvance);
+			setFrame(actionFrameIndex + framesToAdvance);
 		}
 	}
 
 	function setFrame(f: Int) {
-		frame = f;
-
-		var tx = frame % raw.tilesx;
-		var ty = Std.int(frame / raw.tilesx);
-		tileX = tx * (1 / raw.tilesx);
-		tileY = ty * (1 / raw.tilesy);
+		actionFrameIndex = f;
 
 		// Action end
-		if (frame >= action.end && action.start < action.end) {
+		if (currentAction.frames.length > 0 && actionFrameIndex >= currentAction.frames.length) {
 			if (onActionComplete != null) onActionComplete();
-			if (action.loop) setFrame(action.start);
+			if (action.loop) actionFrameIndex = 0;
 			else paused = true;
 		}
 	}

--- a/Sources/iron/object/Uniforms.hx
+++ b/Sources/iron/object/Uniforms.hx
@@ -1013,8 +1013,9 @@ class Uniforms {
 			switch (c.link) {
 				case "_tilesheetOffset": {
 					var ts = cast(object, MeshObject).tilesheet;
-					vx = ts.tileX;
-					vy = ts.tileY;
+					vx = ts.tileUVFrameX;
+					vy = ts.tileUVFrameY;
+					trace('tilesheetOffset: (' + vx + ', ' + vy + ')');
 				}
 				#if arm_morph_target
 				case "_morphScaleOffset": {

--- a/Sources/iron/object/tilesheet/TilesheetActionData.hx
+++ b/Sources/iron/object/tilesheet/TilesheetActionData.hx
@@ -1,0 +1,88 @@
+package iron.object.tilesheet;
+
+import haxe.xml.Access;
+import iron.data.SceneFormat.TTilesheetAction;
+import iron.object.tilesheet.TilesheetFrameData.TilesheetFrame;
+
+class TilesheetActionData {
+    private var parent:TilesheetFrameData;
+
+    private var actionMap:Map<String, TilesheetAction> = new Map<String, TilesheetAction>();
+
+    public function new() {}
+
+    public function getAction(name:String):TilesheetAction {
+        return actionMap.get(name);
+    }
+
+    public function addAction(action:TilesheetAction):Void {
+        if (action == null) return;
+
+        actionMap.set(action.name, action);
+    }
+
+    public static function fromGrid(frameData:TilesheetFrameData, rawActions:Array<TTilesheetAction>) {
+        var actionData:TilesheetActionData = new TilesheetActionData();
+
+        for (rawAction in rawActions) {
+            var action:TilesheetAction = {
+                name: rawAction.name,
+                loop: rawAction.loop,
+                raw: rawAction,
+                frames: []
+            };
+
+            if (rawAction.start < rawAction.end) {
+                for (i in rawAction.start...(rawAction.end + 1)) {
+                    action.frames.push(frameData.getFrameByIndex(i));
+                }
+            }
+
+            actionData.addAction(action);
+        }
+
+        return actionData;
+    }
+
+    public static function fromSparrow(frameData:TilesheetFrameData, rawActions:Array<TTilesheetAction>) {
+        var actionData:TilesheetActionData = new TilesheetActionData();
+
+        for (rawAction in rawActions) {
+            var action:TilesheetAction = {
+                name: rawAction.name,
+                loop: rawAction.loop,
+                raw: rawAction,
+                frames: frameData.getFramesByPrefix(rawAction.prefix)
+            };
+
+            if (action.frames.length == 0) {
+                trace('[WARNING] No frames found for action (${action.name}). Did you specify the correct prefix?');
+                continue;
+            }
+
+            actionData.addAction(action);
+        }
+
+        return actionData;
+    }
+}
+
+typedef TilesheetAction = {
+    /**
+     * The name of the action.
+     */
+    public var name:String;
+
+    /**
+     * An array of frames from the TilesheetFrameData, which the action should reference, in order.
+     */
+     public var frames:Array<TilesheetFrame>;
+
+    /**
+     * Whether the action should loop continuously on completion,
+     * or stop on the last frame.
+     */
+    public var loop:Bool;
+
+    public var raw:TTilesheetAction;
+}

--- a/Sources/iron/object/tilesheet/TilesheetFrameData.hx
+++ b/Sources/iron/object/tilesheet/TilesheetFrameData.hx
@@ -1,0 +1,241 @@
+package iron.object.tilesheet;
+
+import haxe.xml.Access;
+
+class TilesheetFrameData {
+    public var textureWidth:Int = 1;
+    public var textureHeight:Int = 1;
+
+    /**
+     * A list of the tilesheets frames, in order by index.
+     */
+    private var frames:Array<TilesheetFrame> = [];
+
+    /**
+     * A map of the tilesheets frames, keyed by name.
+     */
+    private var framesByName:Map<String, TilesheetFrame> = new Map<String, TilesheetFrame>();
+
+    private function new(textureWidth:Int, textureHeight:Int) {
+        this.textureWidth = textureWidth;
+        this.textureHeight = textureHeight;
+    }
+
+    public function addFrame(frame:TilesheetFrame):Void {
+        if (frame.name != null) {
+            if (framesByName.exists(frame.name)) {
+                return;
+            } else {
+                framesByName.set(frame.name, frame);
+            }
+        }
+
+        frames.push(frame);
+    }
+
+    /**
+     * Retrieves a specific frame by its name.
+     */
+    public inline function getFrameByName(name:String):TilesheetFrame {
+        return framesByName.get(name);
+    }
+
+    /**
+     * Retrieves a specific frame by its index.
+     */
+    public inline function getFrameByIndex(index:Int):TilesheetFrame {
+        return frames[index];
+    }
+
+    /**
+     * Gets the index of a given frame in the list.
+     * @return The index of the frame, or -1 if it doesn't exist.
+     */
+    public function getIndexOfFrame(frame:TilesheetFrame):Int {
+        return frames.indexOf(frame);
+    }
+
+    /**
+     * Gets the index of a frame by its name.
+     * @return The index of the frame, or -1 if it doesn't exist.
+     */
+    public function getIndexByName(name:String):Int {
+        return frames.indexOf(framesByName.get(name));
+    }
+
+    /**
+     * Gets the indices of a list of frames.
+     * @return An array of indices, with the same length and order as the frames.
+     *         If a frame doesn't exist, its index will be -1.
+     */
+    public function getIndicesOfFrames(frames:Array<TilesheetFrame>):Array<Int> {
+        var result:Array<Int> = [];
+        for (frame in frames) {
+            result.push(getIndexOfFrame(frame));
+        }
+        return result;
+    }
+
+    /**
+     * Gets an ordered list of frames whose names start with a given prefix.
+     */
+    public function getFramesByPrefix(prefix:String):Array<TilesheetFrame> {
+        var result:Array<TilesheetFrame> = [];
+        for (frame in frames) {
+            if (StringTools.startsWith(frame.name, prefix)) {
+                result.push(frame);
+            }
+        }
+        return result;
+    }
+
+    public static function fromSparrow(textData:String):TilesheetFrameData {
+        var xmlData:Access = new Access(Xml.parse(textData).firstElement());
+
+        var textureWidth:Int = Std.parseInt(xmlData.att.width);
+        var textureHeight:Int = Std.parseInt(xmlData.att.height);
+        
+        var result:TilesheetFrameData = new TilesheetFrameData(textureWidth, textureHeight);
+
+        for (frame in xmlData.nodes.SubTexture) {
+            var frameData:TilesheetFrame = {
+                name: frame.att.name,
+                x: Std.parseInt(frame.att.x),
+                y: Std.parseInt(frame.att.y),
+                width: Std.parseInt(frame.att.width),
+                height: Std.parseInt(frame.att.height),
+                frameX: 0,
+                frameY: 0,
+                frameWidth: 0,
+                frameHeight: 0,
+                flipX: false,
+                flipY: false,
+                angle: 0
+            };
+
+            if (frame.has.frameX) {
+                frameData.frameX = Std.parseInt(frame.att.frameX);
+                frameData.frameY = Std.parseInt(frame.att.frameY);
+                frameData.frameWidth = Std.parseInt(frame.att.frameWidth);
+                frameData.frameHeight = Std.parseInt(frame.att.frameHeight);
+            } else {
+                frameData.frameX = 0;
+                frameData.frameY = 0;
+                frameData.frameWidth = frameData.width;
+                frameData.frameHeight = frameData.height;
+            }
+            
+            if (frame.has.flipX) {
+                frameData.flipX = Std.parseInt(frame.att.flipX) == 1;
+            }
+            
+            if (frame.has.flipY) {
+                frameData.flipY = Std.parseInt(frame.att.flipY) == 1;
+            }
+
+            if (frame.has.rotated && frame.att.rotated == "true") {
+                frameData.angle = -90;
+            }
+
+            result.addFrame(frameData);
+        }
+
+        return result;
+    }
+
+    public static function fromGrid(width:Int, height:Int):TilesheetFrameData {
+        // We don't know the actual texture width and height, so we make some up.
+        var textureWidth:Int = width * 100;
+        var textureHeight:Int = height * 100;
+
+        var result:TilesheetFrameData = new TilesheetFrameData(textureWidth, textureHeight);
+
+        for (i in 0...width) {
+            for (j in 0...height) {
+                var frame:TilesheetFrame = {
+                    name: "frame_" + i + "_" + j,
+                    x: i * 100,
+                    y: j * 100,
+                    width: 100,
+                    height: 100,
+                    frameX: 0,
+                    frameY: 0,
+                    frameWidth: 100,
+                    frameHeight: 100,
+                    angle: 0,
+                    flipX: false,
+                    flipY: false
+                };
+            
+                result.addFrame(frame);
+            }
+        }
+
+        return result;
+    }
+}
+
+typedef TilesheetFrame = {
+    /**
+     * The name of the frame.
+     */
+    public var name:String;
+
+    // The position and size of the frame to crop from the original image.
+
+    /**
+     * The x position where the source frame starts.
+     */
+    public var x:Int;
+    /**
+     * The y position where the source frame starts.
+     */
+    public var y:Int;
+    /**
+     * The width of the source frame.
+     */
+    public var width:Int;
+    /**
+     * The height of the source frame.
+     */
+    public var height:Int;
+
+    // If the frame was cropped from the original image, these values will provide
+    // the info needed to restore the original image.
+
+    /**
+     * The coordinate relative to x=0 where the image should start.
+     * If the final image should show 10px of padding on the left, `frameX` will be -10.
+     */
+    public var frameX:Int;
+    /**
+     * The coordinate relative to y=0 where the image should start.
+     * If the final image should show 10px of padding on the top, `frameY` will be -10.
+     */
+    public var frameY:Int;
+    /**
+     * The width of the final image.
+     * If the final image should show 10px of padding on the right, `frameWidth` will be 10 higher than the width.
+     */
+    public var frameWidth:Int;
+    /**
+     * The height of the final image.
+     * If the final image should show 10px of padding on the bottom, `frameHeight` will be 10 higher than the height.
+     */
+    public var frameHeight:Int;
+
+    /**
+     * Whether the frame should be flipped horizontally.
+     */
+    public var flipX:Bool;
+    /**
+     * Whether the frame should be flipped vertically.
+     */
+    public var flipY:Bool;
+
+    /**
+     * Rotation of the packed image.
+     * Can be `0`, `90`, or `-90`.
+     */
+    public var angle:Float;
+}


### PR DESCRIPTION
The current implementation of Tilesheets in Armory is very limited. It only provides support for grids of square sprites, and playing a range of frames from the grid in order. This is highly inefficient, as it does not allow the spritesheet to be optimized or frames to be reused.

This pull request implements engine support for the Sparrow sprite format, which associates an XML file with the spritesheet, which looks like so:

```
<TextureAtlas imagePath="atlas.png">
 <SubTexture name="idle001" x="0" y="0" width="30" height="30"/>;
 <SubTexture name="idle002" x="30" y="0" width="65" height="78"/>;
 <SubTexture name="walk001" x="30" y="80" width="65" height="78"/>;
 <SubTexture name="walk002" x="30" y="80" width="65" height="78"/>;
 ...
</TextureAtlas>;
```

These spritesheets can be generated by programs such as TexturePacker or Adobe Animate.

Developers can then specify frames by prefix, for example the Walk animation will use the frames with the name `walk`, in order.

Care was taken to ensure relatively few breaking changes were made to the Tilesheet class, but a more optimal code structure may require a rework to Tilesheet (such as making tilesheet a parent to GridTilesheet and SparrowTilesheet subclasses).

There is also room to add additional file formats as users request them.

## TODO

- [ ] Fix implementation of frameX, frameY, frameWidth, and frameHeight. Parts of the spritesheet outside the current frame should be hidden. I couldn't figure out how to do this, changes need to be made to the shader code somewhere.
- [ ] Implement `flipX`, `flipY`, and `rotate` attributes. These indicate that the frame should be rendered flipped horizontally, flipped vertically, or rotated by 90 degrees, respectively. These attributes are used to further optimize a spritesheet by minimizing transparent space.

## Note

This pull request is associated with armory3d/armory#2745, and will not function as intended without it.