### PR TITLE
Build transform matrix after set parent

### DIFF
--- a/Sources/iron/object/Object.hx
+++ b/Sources/iron/object/Object.hx
@@ -66,6 +66,7 @@ class Object {
 		parent = parentObject;
 		parent.children.push(this);
 		if (parentInverse) this.transform.applyParentInverse();
+		if(Scene.active.ready) this.transform.buildMatrix();
 	}
 
 	/**


### PR DESCRIPTION
In some cases such as when `Keep Transform = true` and `Parent Inverse = false`, after setting the parent, `buildMatrix` was not applied to the child objects.