### PR TITLE
New getNumBones() method

### DIFF
--- a/Sources/iron/object/BoneAnimation.hx
+++ b/Sources/iron/object/BoneAnimation.hx
@@ -66,6 +66,11 @@ class BoneAnimation extends Animation {
 		}
 	}
 
+	public inline function getNumBones(): Int {
+    	if (skeletonBones == null) return 0;
+    	return skeletonBones.length;
+	}
+
 	public function setSkin(mo: MeshObject) {
 		this.object = mo;
 		this.data = mo != null ? mo.data : null;


### PR DESCRIPTION
This new method returns the length of bones for an exported animation (great for debugging purposes).

Special thanks to @MoritzBrueckner and @QuantumCoderQC for review and suggestions.