### PR TITLE
Add Vec4 moveTowards method

### DIFF
--- a/Sources/iron/math/Vec4.hx
+++ b/Sources/iron/math/Vec4.hx
@@ -208,6 +208,17 @@ class Vec4 {
 		return this;
 	}
 
+	public inline function moveToward(v: Vec4, delta: FastFloat): Vec4 {
+		var target = v.clone();
+		var diff = target.sub(this);
+		var l = diff.length();
+
+		if (l <= delta || l == 0.0) setFrom(v);
+		else add(diff.mult(1.0 / l * delta));
+
+		return this;
+	}
+
 	public static inline function xAxis(): Vec4 {
 		return new Vec4(1.0, 0.0, 0.0);
 	}

--- a/Sources/iron/math/Vec4.hx
+++ b/Sources/iron/math/Vec4.hx
@@ -208,7 +208,7 @@ class Vec4 {
 		return this;
 	}
 
-	public inline function moveToward(v: Vec4, delta: FastFloat): Vec4 {
+	public inline function moveTowards(v: Vec4, delta: FastFloat): Vec4 {
 		var target = v.clone();
 		var diff = target.sub(this);
 		var l = diff.length();


### PR DESCRIPTION
The function allows incrementing the value of vector A until reaching the value of vector B. Useful for procedural linear animations and acceleration.