### PR TITLE
Add vertex_map parameter required for mapping indices

### DIFF
--- a/Sources/iron/data/SceneFormat.hx
+++ b/Sources/iron/data/SceneFormat.hx
@@ -109,6 +109,7 @@ typedef TIndexArray = {
 #end
 	public var values: Uint32Array; // size = 3
 	public var material: Int;
+	@:optional public var vertex_map: Uint32Array; // size = 3
 }
 
 #if js


### PR DESCRIPTION
Add a new optional index attribute to map vertex index to index buffer.