### PR TITLE
Fix black screen and display warning if referenced group doesn't exist

### DIFF
--- a/Sources/iron/Scene.hx
+++ b/Sources/iron/Scene.hx
@@ -573,7 +573,7 @@ class Scene {
 			var object = addObject(parent);
 			returnObject(object, o, function(ro: Object) {
 				if (o.group_ref != null) { // Instantiate group objects
-					spawnGroup(format, o.group_ref, ro, function() { done(ro); });
+					spawnGroup(format, o.group_ref, ro, () -> done(ro), () -> done(ro) /* also call done when failed to ensure loading progress */);
 				}
 				else done(ro);
 			});
@@ -586,6 +586,7 @@ class Scene {
 		var object_refs = getGroupObjectRefs(groupRef, format);
 
 		if (object_refs == null) { // Group doesn't exist
+			trace('Failed to spawn group "$groupRef", group doesn\'t exist');
 			if (failed != null) failed();
 		}
 		else if (object_refs.length == 0) {


### PR DESCRIPTION
Related to https://github.com/armory3d/armory/pull/2902; this PR prevents a black screen if Iron could not find a referenced group. Even if loading a group fails we now call `done()` to ensure that object counting in `traverseObjects()` continues and eventually calls the higher-level `done` callback to start the scene. This change might cause further errors down the line, but it will be much easier to debug (following callback after callback is no fun) especially with the new warning. Let me know if you only want the warning and keep the black screen, then I can remove that part again (or feel free to remove it yourself).