### PR TITLE
Fix Tilesheet Frame and Time

### DIFF
--- a/Sources/iron/object/Tilesheet.hx
+++ b/Sources/iron/object/Tilesheet.hx
@@ -101,16 +101,17 @@ class Tilesheet {
 	function setFrame(f: Int) {
 		frame = f;
 
+		// Action end
+		if (frame > action.end && action.start < action.end) {
+			if (onActionComplete != null) onActionComplete();
+			if (action.loop) setFrame(action.start);
+			else paused = true;
+			return;
+		}
+
 		var tx = frame % raw.tilesx;
 		var ty = Std.int(frame / raw.tilesx);
 		tileX = tx * (1 / raw.tilesx);
 		tileY = ty * (1 / raw.tilesy);
-
-		// Action end
-		if (frame >= action.end && action.start < action.end) {
-			if (onActionComplete != null) onActionComplete();
-			if (action.loop) setFrame(action.start);
-			else paused = true;
-		}
 	}
 }

--- a/Sources/iron/object/Tilesheet.hx
+++ b/Sources/iron/object/Tilesheet.hx
@@ -45,6 +45,7 @@ class Tilesheet {
 		}
 		setFrame(action.start);
 		paused = false;
+		time = 0.0;
 	}
 
 	public function pause() {


### PR DESCRIPTION
This PR fixes two issues.

1. When the tilesheet animation is played, the animation time was not reset to 0, causing the first tilesheet animation frame to be of arbitrary duration. This led to inconsistent animation playback.
2. When looping was enabled, the last frame of the animation was not played. It instead immediately looped back to the first frame.

Thanks to user d1csord on Discord for reporting the issue and testing the fix.