### PR TITLE
Add support for 24 light.

### DIFF
--- a/Sources/iron/object/LightObject.hx
+++ b/Sources/iron/object/LightObject.hx
@@ -634,6 +634,8 @@ class LightObject extends Object {
 		return 8;
 		#elseif (rp_max_lights == 16)
 		return 16;
+		#elseif (rp_max_lights == 24)
+		return 24;
 		#elseif (rp_max_lights == 32)
 		return 32;
 		#elseif (rp_max_lights == 64)
@@ -648,6 +650,8 @@ class LightObject extends Object {
 		return 8;
 		#elseif (rp_max_lights_cluster == 16)
 		return 16;
+		#elseif (rp_max_lights_cluster == 24)
+		return 24;
 		#elseif (rp_max_lights_cluster == 32)
 		return 32;
 		#elseif (rp_max_lights_cluster == 64)


### PR DESCRIPTION
Here nothing much but the atlas offers an option to use 24 lights and this option isn't present in the function that returns the maximum number of lights / lights shadows. So we just add it.