### PR TITLE
Gi clipmaps

### DIFF
--- a/Sources/iron/RenderPath.hx
+++ b/Sources/iron/RenderPath.hx
@@ -689,7 +689,7 @@ class RenderPath {
 			// Image only
 			var img = Image.create3D(width, height, depth,
 				t.format != null ? getTextureFormat(t.format) : TextureFormat.RGBA32);
-			if (t.mipmaps) img.generateMipmaps(1000); // Allocate mipmaps
+			if (t.mipmaps) img.generateMipmaps(Main.voxelgiClipmapCount); // Allocate mipmaps
 				return img;
 		}
 		else { // 2D texture

--- a/Sources/iron/object/Uniforms.hx
+++ b/Sources/iron/object/Uniforms.hx
@@ -181,11 +181,17 @@ class Uniforms {
 						// Multiple voxel volumes, always set params
 						g.setImageTexture(context.textureUnits[j], rt.image); // image2D/3D
 						if (rt.raw.name.startsWith("voxels_")) {
-							g.setTextureParameters(context.textureUnits[j], TextureAddressing.Clamp, TextureAddressing.Clamp, TextureFilter.LinearFilter, TextureFilter.LinearFilter, MipMapFilter.LinearMipFilter);
+							g.setTextureParameters(context.textureUnits[j], TextureAddressing.Clamp, TextureAddressing.Clamp, TextureFilter.LinearFilter, TextureFilter.LinearFilter, MipMapFilter.NoMipFilter);
 						}
-						else if (rt.raw.name.startsWith("voxels")) {
-							g.setTexture3DParameters(context.textureUnits[j], TextureAddressing.Mirror, TextureAddressing.Mirror, TextureAddressing.Mirror, TextureFilter.LinearFilter, TextureFilter.PointFilter, MipMapFilter.NoMipFilter);
+						else if (rt.raw.name.startsWith("voxelsOut"))
+						{
+							g.setTexture3DParameters(context.textureUnits[j], TextureAddressing.Clamp, TextureAddressing.Clamp, TextureAddressing.Clamp, TextureFilter.PointFilter, TextureFilter.PointFilter, MipMapFilter.LinearMipFilter);
 						}
+						else
+						{
+							g.setTexture3DParameters(context.textureUnits[j], TextureAddressing.Clamp, TextureAddressing.Clamp, TextureAddressing.Clamp, TextureFilter.LinearFilter, TextureFilter.LinearFilter, MipMapFilter.NoMipFilter);
+						}
+
 						paramsSet = true;
 					}
 					else if (rt.isCubeMap) {

--- a/Sources/iron/object/Uniforms.hx
+++ b/Sources/iron/object/Uniforms.hx
@@ -181,17 +181,16 @@ class Uniforms {
 						// Multiple voxel volumes, always set params
 						g.setImageTexture(context.textureUnits[j], rt.image); // image2D/3D
 						if (rt.raw.name.startsWith("voxels_")) {
-							g.setTextureParameters(context.textureUnits[j], TextureAddressing.Clamp, TextureAddressing.Clamp, TextureFilter.LinearFilter, TextureFilter.LinearFilter, MipMapFilter.NoMipFilter);
+							g.setTextureParameters(context.textureUnits[j], TextureAddressing.Clamp, TextureAddressing.Clamp, TextureFilter.LinearFilter, TextureFilter.LinearFilter, MipMapFilter.LinearMipFilter);
 						}
 						else if (rt.raw.name.startsWith("voxelsOut"))
 						{
 							g.setTexture3DParameters(context.textureUnits[j], TextureAddressing.Clamp, TextureAddressing.Clamp, TextureAddressing.Clamp, TextureFilter.PointFilter, TextureFilter.PointFilter, MipMapFilter.LinearMipFilter);
 						}
-						else
+						else if (rt.raw.name.startsWith("voxels"))
 						{
 							g.setTexture3DParameters(context.textureUnits[j], TextureAddressing.Clamp, TextureAddressing.Clamp, TextureAddressing.Clamp, TextureFilter.LinearFilter, TextureFilter.LinearFilter, MipMapFilter.NoMipFilter);
 						}
-
 						paramsSet = true;
 					}
 					else if (rt.isCubeMap) {


### PR DESCRIPTION
Last commit for clipmaps.
- Adds an extra check to leave room for potential 3D images that are not related to voxels.
- Don't use Mirror for borders because the clipmaps are stacked on the Y axis on one image.
