### PR TITLE
undo changes to tilesheet, allocate 1000 mipmaps, use linear filters

### DIFF
--- a/Sources/iron/RenderPath.hx
+++ b/Sources/iron/RenderPath.hx
@@ -689,7 +689,7 @@ class RenderPath {
 			// Image only
 			var img = Image.create3D(width, height, depth,
 				t.format != null ? getTextureFormat(t.format) : TextureFormat.RGBA32);
-			if (t.mipmaps) img.generateMipmaps(Main.voxelgiClipmapCount); // Allocate mipmaps
+			if (t.mipmaps) img.generateMipmaps(1000); // Allocate mipmaps
 				return img;
 		}
 		else { // 2D texture

--- a/Sources/iron/object/Uniforms.hx
+++ b/Sources/iron/object/Uniforms.hx
@@ -183,13 +183,13 @@ class Uniforms {
 						if (rt.raw.name.startsWith("voxels_")) {
 							g.setTextureParameters(context.textureUnits[j], TextureAddressing.Clamp, TextureAddressing.Clamp, TextureFilter.LinearFilter, TextureFilter.LinearFilter, MipMapFilter.LinearMipFilter);
 						}
-						else if (rt.raw.name.startsWith("voxelsOut"))
-						{
-							g.setTexture3DParameters(context.textureUnits[j], TextureAddressing.Clamp, TextureAddressing.Clamp, TextureAddressing.Clamp, TextureFilter.PointFilter, TextureFilter.PointFilter, MipMapFilter.LinearMipFilter);
-						}
 						else if (rt.raw.name.startsWith("voxels"))
 						{
-							g.setTexture3DParameters(context.textureUnits[j], TextureAddressing.Clamp, TextureAddressing.Clamp, TextureAddressing.Clamp, TextureFilter.LinearFilter, TextureFilter.LinearFilter, MipMapFilter.NoMipFilter);
+							g.setTexture3DParameters(context.textureUnits[j], TextureAddressing.Clamp, TextureAddressing.Clamp, TextureAddressing.Clamp, TextureFilter.LinearFilter, TextureFilter.LinearFilter, MipMapFilter.LinearMipFilter);
+						}
+						else
+						{
+							g.setTextureParameters(context.textureUnits[j], TextureAddressing.Clamp, TextureAddressing.Clamp, TextureFilter.LinearFilter, TextureFilter.LinearFilter, MipMapFilter.LinearMipFilter);
 						}
 						paramsSet = true;
 					}


### PR DESCRIPTION
Hi, last change, I've made a mistake by using point filters.
We set everything to linear, also we just allocate size for 1000 mipmaps like in legacy, even though we don't use mipmaps (it doesn't work when images are not mipmaps and not allocated even though we use textureLod with level 0 only).

This is done for me, only voxels shadows option has no effect.
https://github.com/armory3d/armory/pull/3012

