### PR TITLE
Gi clipmaps fix latency and crashes

### DIFF
--- a/Sources/iron/RenderPath.hx
+++ b/Sources/iron/RenderPath.hx
@@ -83,6 +83,8 @@ class RenderPath {
 		return 64;
 		#elseif (rp_voxelgi_resolution == 32)
 		return 32;
+		#elseif (rp_voxelgi_resolution == 16)
+		return 16;
 		#else
 		return 0;
 		#end
@@ -689,15 +691,17 @@ class RenderPath {
 			// Image only
 			var img = Image.create3D(width, height, depth,
 				t.format != null ? getTextureFormat(t.format) : TextureFormat.RGBA32);
-			if (t.mipmaps) img.generateMipmaps(1000); // Allocate mipmaps
-				return img;
+			if (t.mipmaps)
+				img.generateMipmaps(1); // Allocate mipmaps
+			return img;
 		}
 		else { // 2D texture
 			if (t.is_image != null && t.is_image) { // Image
 				var img = Image.create(width, height,
 					t.format != null ? getTextureFormat(t.format) : TextureFormat.RGBA32);
-				if (t.mipmaps) img.generateMipmaps(1000); // Allocate mipmaps
-					return img;
+				if (t.mipmaps)
+					img.generateMipmaps(16); // Allocate mipmaps
+				return img;
 			}
 			else { // Render target
 				return Image.createRenderTarget(width, height,

--- a/Sources/iron/RenderPath.hx
+++ b/Sources/iron/RenderPath.hx
@@ -689,11 +689,7 @@ class RenderPath {
 		if (height < 1) height = 1;
 		if (t.depth != null && t.depth > 1) { // 3D texture
 			// Image only
-			var img = Image.create3D(width, height, depth,
-				t.format != null ? getTextureFormat(t.format) : TextureFormat.RGBA32);
-			if (t.mipmaps)
-				img.generateMipmaps(1); // Allocate mipmaps
-			return img;
+			return Image.create3D(width, height, depth, t.format != null ? getTextureFormat(t.format) : TextureFormat.RGBA32);
 		}
 		else { // 2D texture
 			if (t.is_image != null && t.is_image) { // Image

--- a/Sources/iron/RenderPath.hx
+++ b/Sources/iron/RenderPath.hx
@@ -689,14 +689,18 @@ class RenderPath {
 		if (height < 1) height = 1;
 		if (t.depth != null && t.depth > 1) { // 3D texture
 			// Image only
-			return Image.create3D(width, height, depth, t.format != null ? getTextureFormat(t.format) : TextureFormat.RGBA32);
+			var img = Image.create3D(width, height, depth,
+				t.format != null ? getTextureFormat(t.format) : TextureFormat.RGBA32);
+			if (t.mipmaps)
+				img.generateMipmaps(1000); // Allocate mipmaps
+			return img;
 		}
 		else { // 2D texture
 			if (t.is_image != null && t.is_image) { // Image
 				var img = Image.create(width, height,
 					t.format != null ? getTextureFormat(t.format) : TextureFormat.RGBA32);
 				if (t.mipmaps)
-					img.generateMipmaps(16); // Allocate mipmaps
+					img.generateMipmaps(1000); // Allocate mipmaps
 				return img;
 			}
 			else { // Render target

--- a/Sources/iron/object/LightObject.hx
+++ b/Sources/iron/object/LightObject.hx
@@ -18,7 +18,7 @@ class LightObject extends Object {
 	public var lightInAtlas = false;
 	public var culledLight = false;
 	public static var pointLightsData: kha.arrays.Float32Array = null;
-	public var shadowMapScale = 0.0;
+	public var shadowMapScale = 1.0; // When in forward if this defaults to 0.0, the atlas are not drawn before being bound.
 	// Data used in uniforms
 	public var tileOffsetX: Array<Float> = [0.0];
 	public var tileOffsetY: Array<Float> = [0.0];

--- a/Sources/iron/object/LightObject.hx
+++ b/Sources/iron/object/LightObject.hx
@@ -18,7 +18,7 @@ class LightObject extends Object {
 	public var lightInAtlas = false;
 	public var culledLight = false;
 	public static var pointLightsData: kha.arrays.Float32Array = null;
-	public var shadowMapScale = 1.0;//when in forward, we drawMeshes() which will set this only after drawing shadowmap. This locks the drawing of the atlases so it's better to initialize it at 1.0
+	public var shadowMapScale = 1.0;//when in forward, we drawMeshes() which will set this only after drawing shadowmap. This blocks the drawing of the atlases so it's better to initialize it at 1.0
 	// Data used in uniforms
 	public var tileOffsetX: Array<Float> = [0.0];
 	public var tileOffsetY: Array<Float> = [0.0];

--- a/Sources/iron/object/LightObject.hx
+++ b/Sources/iron/object/LightObject.hx
@@ -18,7 +18,7 @@ class LightObject extends Object {
 	public var lightInAtlas = false;
 	public var culledLight = false;
 	public static var pointLightsData: kha.arrays.Float32Array = null;
-	public var shadowMapScale = 1.0;//when in forward, we drawMeshes() which will set this only after drawing shadowmap. This blocks the drawing of the atlases so it's better to initialize it at 1.0
+	public var shadowMapScale = 0.0;
 	// Data used in uniforms
 	public var tileOffsetX: Array<Float> = [0.0];
 	public var tileOffsetY: Array<Float> = [0.0];

--- a/Sources/iron/object/LightObject.hx
+++ b/Sources/iron/object/LightObject.hx
@@ -18,7 +18,7 @@ class LightObject extends Object {
 	public var lightInAtlas = false;
 	public var culledLight = false;
 	public static var pointLightsData: kha.arrays.Float32Array = null;
-	public var shadowMapScale = 0.0;
+	public var shadowMapScale = 1.0;//when in forward, we drawMeshes() which will set this only after drawing shadowmap. This locks the drawing of the atlases so it's better to initialize it at 1.0
 	// Data used in uniforms
 	public var tileOffsetX: Array<Float> = [0.0];
 	public var tileOffsetY: Array<Float> = [0.0];

--- a/Sources/iron/object/Uniforms.hx
+++ b/Sources/iron/object/Uniforms.hx
@@ -181,11 +181,11 @@ class Uniforms {
 						// Multiple voxel volumes, always set params
 						g.setImageTexture(context.textureUnits[j], rt.image); // image2D/3D
 						if (rt.raw.name.startsWith("voxels_")) {
-							g.setTextureParameters(context.textureUnits[j], TextureAddressing.Clamp, TextureAddressing.Clamp, TextureFilter.LinearFilter, TextureFilter.LinearFilter, MipMapFilter.LinearMipFilter);
+							g.setTextureParameters(context.textureUnits[j], TextureAddressing.Clamp, TextureAddressing.Clamp, TextureFilter.LinearFilter, TextureFilter.LinearFilter, MipMapFilter.NoMipFilter);
 						}
 						else if (rt.raw.name.startsWith("voxels"))
 						{
-							g.setTexture3DParameters(context.textureUnits[j], TextureAddressing.Clamp, TextureAddressing.Clamp, TextureAddressing.Clamp, TextureFilter.LinearFilter, TextureFilter.LinearFilter, MipMapFilter.LinearMipFilter);
+							g.setTexture3DParameters(context.textureUnits[j], TextureAddressing.Clamp, TextureAddressing.Clamp, TextureAddressing.Clamp, TextureFilter.LinearFilter, TextureFilter.PointFilter, MipMapFilter.NoMipFilter);
 						}
 						else
 						{

--- a/Sources/iron/object/Uniforms.hx
+++ b/Sources/iron/object/Uniforms.hx
@@ -185,7 +185,7 @@ class Uniforms {
 						}
 						else if (rt.raw.name.startsWith("voxels"))
 						{
-							g.setTexture3DParameters(context.textureUnits[j], TextureAddressing.Clamp, TextureAddressing.Clamp, TextureAddressing.Clamp, TextureFilter.LinearFilter, TextureFilter.PointFilter, MipMapFilter.NoMipFilter);
+							g.setTexture3DParameters(context.textureUnits[j], TextureAddressing.Clamp, TextureAddressing.Clamp, TextureAddressing.Clamp, TextureFilter.LinearFilter, TextureFilter.LinearFilter, MipMapFilter.NoMipFilter);
 						}
 						else
 						{


### PR DESCRIPTION
Fixes crashes when allocating mipmaps for 3D images.
I think that the pc runs out of ram because mipmapping for 3d images is, correct my if i'm wrong, 8 times the size of the original image. And anisotropy, precomputed direction, and clipmaps are stored in these images by extending their sizes so we don't use mipmaps.

@luboslenco this is kind of crucial that you merge this one, I'm opening an 'overhaul' pull request for armory but even with the current code the patch is needed.