### PR TITLE
Use visibleShadow, get rid of visibleMesh

### DIFF
--- a/Sources/iron/Scene.hx
+++ b/Sources/iron/Scene.hx
@@ -828,7 +828,6 @@ class Scene {
 			object.raw = o;
 			object.name = o.name;
 			if (o.visible != null) object.visible = o.visible;
-			if (o.visible_mesh != null) object.visibleMesh = o.visible_mesh;
 			if (o.visible_shadow != null) object.visibleShadow = o.visible_shadow;
 
 			createConstraints(o.constraints, object);

--- a/Sources/iron/Scene.hx
+++ b/Sources/iron/Scene.hx
@@ -830,6 +830,7 @@ class Scene {
 			if (o.visible != null) object.visible = o.visible;
 			if (o.visible_mesh != null) object.visibleMesh = o.visible_mesh;
 			if (o.visible_shadow != null) object.visibleShadow = o.visible_shadow;
+
 			createConstraints(o.constraints, object);
 			generateTransform(o, object.transform);
 			object.setupAnimation(oactions);

--- a/Sources/iron/data/SceneFormat.hx
+++ b/Sources/iron/data/SceneFormat.hx
@@ -451,6 +451,7 @@ typedef TObj = {
 	@:optional public var visible: Null<Bool>;
 	@:optional public var visible_mesh: Null<Bool>;
 	@:optional public var visible_shadow: Null<Bool>;
+	@:optional public var only_shadows: Null<Bool>;
 	@:optional public var mobile: Null<Bool>;
 	@:optional public var spawn: Null<Bool>; // Auto add object when creating scene
 	@:optional public var local_only: Null<Bool>; // Apply parent matrix

--- a/Sources/iron/object/MeshObject.hx
+++ b/Sources/iron/object/MeshObject.hx
@@ -161,8 +161,8 @@ class MeshObject extends Object {
 		if (!isLodMaterial() && !validContext(mats, context)) return true;
 
 		var isShadow = context == "shadowmap";
-		if (!visibleMesh && !isShadow) return setCulled(isShadow, true);
-		if (!visibleShadow && isShadow) return setCulled(isShadow, true);
+		if (!visible && !isShadow) return setCulled(isShadow, true);
+		//if (!visibleShadow && isShadow) return setCulled(isShadow, true);
 
 		if (skip_context == context) return setCulled(isShadow, true);
 		if (force_context != null && force_context != context) return setCulled(isShadow, true);

--- a/Sources/iron/object/MeshObject.hx
+++ b/Sources/iron/object/MeshObject.hx
@@ -230,7 +230,8 @@ class MeshObject extends Object {
 
 	public function render(g: Graphics, context: String, bindParams: Array<String>) {
 		if (data == null || !data.geom.ready) return; // Data not yet streamed
-		if (!visible) return; // Skip render if object is hidden
+		if (!visible && !visibleShadow) return; // Skip render if object is hidden
+		if ((visibleShadow && !visible) && context != "voxel" && context != "shadowmap") return;
 		if (cullMesh(context, Scene.active.camera, RenderPath.active.light)) return;
 		var meshContext = raw != null ? context == "mesh" : false;
 


### PR DESCRIPTION
First, this isn't a modification for voxels anymore despite the name of the branch.
This pull request allows the game creator to make an object invisible while it still contributes to the  lighting.
![Capture d’écran du 2024-08-12 12-16-13](https://github.com/user-attachments/assets/cf83c6ab-2722-46ac-90ef-29c85a7ea977)

![Capture d’écran du 2024-08-12 12-15-45](https://github.com/user-attachments/assets/24d0d951-70bf-40a6-9a5c-49fb62d0abcb)

The armory part is in the oberhaul pull request.