### PR TITLE
Visible shadows

### DIFF
--- a/Sources/iron/Scene.hx
+++ b/Sources/iron/Scene.hx
@@ -828,8 +828,8 @@ class Scene {
 			object.raw = o;
 			object.name = o.name;
 			if (o.visible != null) object.visible = o.visible;
-			if (o.visible_mesh != null) object.visibleMesh = o.visible_mesh;
 			if (o.visible_shadow != null) object.visibleShadow = o.visible_shadow;
+
 			createConstraints(o.constraints, object);
 			generateTransform(o, object.transform);
 			object.setupAnimation(oactions);

--- a/Sources/iron/data/SceneFormat.hx
+++ b/Sources/iron/data/SceneFormat.hx
@@ -451,6 +451,7 @@ typedef TObj = {
 	@:optional public var visible: Null<Bool>;
 	@:optional public var visible_mesh: Null<Bool>;
 	@:optional public var visible_shadow: Null<Bool>;
+	@:optional public var only_shadows: Null<Bool>;
 	@:optional public var mobile: Null<Bool>;
 	@:optional public var spawn: Null<Bool>; // Auto add object when creating scene
 	@:optional public var local_only: Null<Bool>; // Apply parent matrix

--- a/Sources/iron/object/LightObject.hx
+++ b/Sources/iron/object/LightObject.hx
@@ -19,7 +19,7 @@ class LightObject extends Object {
 	public var lightInAtlasTransparent = false;
 	public var culledLight = false;
 	public static var pointLightsData: kha.arrays.Float32Array = null;
-	public var shadowMapScale = 0.0; // When in forward if this defaults to 0.0, the atlas are not drawn before being bound.
+	public var shadowMapScale = 1.0; // When in forward if this defaults to 0.0, the atlas are not drawn before being bound.
 	// Data used in uniforms
 	public var tileOffsetX: Array<Float> = [0.0];
 	public var tileOffsetY: Array<Float> = [0.0];

--- a/Sources/iron/object/LightObject.hx
+++ b/Sources/iron/object/LightObject.hx
@@ -16,9 +16,10 @@ class LightObject extends Object {
 	#if arm_shadowmap_atlas
 	public var tileNotifyOnRemove: Void -> Void;
 	public var lightInAtlas = false;
+	public var lightInAtlasTransparent = false;
 	public var culledLight = false;
 	public static var pointLightsData: kha.arrays.Float32Array = null;
-	public var shadowMapScale = 1.0; // When in forward if this defaults to 0.0, the atlas are not drawn before being bound.
+	public var shadowMapScale = 0.0; // When in forward if this defaults to 0.0, the atlas are not drawn before being bound.
 	// Data used in uniforms
 	public var tileOffsetX: Array<Float> = [0.0];
 	public var tileOffsetY: Array<Float> = [0.0];

--- a/Sources/iron/object/MeshObject.hx
+++ b/Sources/iron/object/MeshObject.hx
@@ -161,7 +161,7 @@ class MeshObject extends Object {
 		if (!isLodMaterial() && !validContext(mats, context)) return true;
 
 		var isShadow = context == "shadowmap";
-		if (!visibleMesh && !isShadow) return setCulled(isShadow, true);
+		if (!visible && !isShadow) return setCulled(isShadow, true);
 		if (!visibleShadow && isShadow) return setCulled(isShadow, true);
 
 		if (skip_context == context) return setCulled(isShadow, true);
@@ -230,7 +230,8 @@ class MeshObject extends Object {
 
 	public function render(g: Graphics, context: String, bindParams: Array<String>) {
 		if (data == null || !data.geom.ready) return; // Data not yet streamed
-		if (!visible) return; // Skip render if object is hidden
+		if (!visible && !visibleShadow) return; // Skip render if object is hidden
+		if ((visibleShadow && !visible) && context != "voxel" && context != "shadowmap") return;
 		if (cullMesh(context, Scene.active.camera, RenderPath.active.light)) return;
 		var meshContext = raw != null ? context == "mesh" : false;
 


### PR DESCRIPTION
This is a little modification to iron to let game designers place invisible objects that still cast shadows (and voxels lighting / ao).
Now to make the object completelly invisible, user has to disable the render in the outliner and also light in armory's props in object panel.
Shadows and light are independent of one another when culling, to be able to have objects that contribute to lighting while being invisible, and the other way around to be visible but not contribute to the lighting.
This is possible to disable the second options and have the object completely disappear when set to invisible. But that's two different commits.  