### PR TITLE
don't use mipmaps for 3D samplers.

### DIFF
--- a/Sources/iron/object/Uniforms.hx
+++ b/Sources/iron/object/Uniforms.hx
@@ -173,7 +173,7 @@ class Uniforms {
 					var paramsSet = false;
 
 					if (rt.raw.depth > 1) { // sampler3D
-						g.setTexture3DParameters(context.textureUnits[j], TextureAddressing.Clamp, TextureAddressing.Clamp, TextureAddressing.Clamp, TextureFilter.LinearFilter, TextureFilter.AnisotropicFilter, MipMapFilter.LinearMipFilter);
+						g.setTexture3DParameters(context.textureUnits[j], TextureAddressing.Clamp, TextureAddressing.Clamp, TextureAddressing.Clamp, TextureFilter.LinearFilter, TextureFilter.AnisotropicFilter, MipMapFilter.NoMipFilter);
 						paramsSet = true;
 					}
 


### PR DESCRIPTION
There is a remnant of mipmaps for samplers, I had not noticed it but since a lot of 3D targets for voxels as passed as samplers, it's better to get rid of this, even though I think it has no impact. 